### PR TITLE
fix definition overwriting with web3-1.0.0 target

### DIFF
--- a/lib/targets/web3/index.ts
+++ b/lib/targets/web3/index.ts
@@ -36,7 +36,7 @@ export class Web3 extends TsGeneratorPlugin {
     const contract = parse(abi, name);
 
     return {
-      path: join(this.outDirAbs, "index.d.ts"),
+      path: join(this.outDirAbs, `${name}.ts`),
       contents: codegen(contract),
     };
   }


### PR DESCRIPTION
Fixes bug with web3-1.0.0 target - Each generated definition file is written to "index.d.ts" so with multiple contracts each one overwrites the last as it is generated.