### PR TITLE
[legacy] correctly pass boolean arguments in methods

### DIFF
--- a/__snapshots__/DumbContract.spec.ts.js
+++ b/__snapshots__/DumbContract.spec.ts.js
@@ -226,7 +226,7 @@ export class DumbContract extends TC.TypeChainContract {
   }
 
   public callWithBoolean(boolParam: boolean): Promise<boolean> {
-    return TC.promisify(this.rawWeb3Contract.callWithBoolean, [boolParam.toString()]);
+    return TC.promisify(this.rawWeb3Contract.callWithBoolean, [boolParam]);
   }
 
   public callWithArray2(arrayParam: BigNumber[]): Promise<BigNumber[]> {

--- a/__snapshots__/DumbContract.spec.ts.js
+++ b/__snapshots__/DumbContract.spec.ts.js
@@ -114,6 +114,15 @@ export class DumbContract extends TC.TypeChainContract {
       },
       {
         constant: true,
+        inputs: [{ name: "boolArrayParam", type: "bool[]" }],
+        name: "callWithBooleanArray",
+        outputs: [{ name: "", type: "bool[]" }],
+        payable: false,
+        stateMutability: "pure",
+        type: "function",
+      },
+      {
+        constant: true,
         inputs: [{ name: "", type: "uint256" }],
         name: "counterArray",
         outputs: [{ name: "", type: "uint256" }],
@@ -231,7 +240,7 @@ export class DumbContract extends TC.TypeChainContract {
 
   public callWithArray2(arrayParam: BigNumber[]): Promise<BigNumber[]> {
     return TC.promisify(this.rawWeb3Contract.callWithArray2, [
-      arrayParam.map(val => val.toString()),
+      arrayParam.map(arrayParamElem => arrayParamElem.toString()),
     ]);
   }
 
@@ -241,6 +250,12 @@ export class DumbContract extends TC.TypeChainContract {
 
   public testString(a: string): Promise<string> {
     return TC.promisify(this.rawWeb3Contract.testString, [a.toString()]);
+  }
+
+  public callWithBooleanArray(boolArrayParam: boolean[]): Promise<boolean[]> {
+    return TC.promisify(this.rawWeb3Contract.callWithBooleanArray, [
+      boolArrayParam.map(boolArrayParamElem => boolArrayParamElem),
+    ]);
   }
 
   public counterArray(arg0: BigNumber | number): Promise<BigNumber> {
@@ -279,7 +294,7 @@ export class DumbContract extends TC.TypeChainContract {
   }
   public callWithArrayTx(arrayParam: BigNumber[]): TC.DeferredTransactionWrapper<TC.ITxParams> {
     return new TC.DeferredTransactionWrapper<TC.ITxParams>(this, "callWithArray", [
-      arrayParam.map(val => val.toString()),
+      arrayParam.map(arrayParamElem => arrayParamElem.toString()),
     ]);
   }
 

--- a/lib/targets/legacy/generation.ts
+++ b/lib/targets/legacy/generation.ts
@@ -146,9 +146,10 @@ function codeGenForParams(param: AbiParameter, index: number): string {
 }
 
 function codeGenForArgs(param: AbiParameter, index: number): string {
-  const isArray = param.type instanceof ArrayType;
   const paramName = param.name || `arg${index}`;
-  return isArray ? `${paramName}.map(val => val.toString())` : `${paramName}.toString()`;
+  if (param.type instanceof ArrayType) return `${paramName}.map(val => val.toString())`;
+  if (param.type instanceof BooleanType) return paramName;
+  return `${paramName}.toString()`;
 }
 
 function codeGenForOutputTypeList(output: Array<AbiParameter>): string {

--- a/lib/targets/legacy/generation.ts
+++ b/lib/targets/legacy/generation.ts
@@ -147,7 +147,10 @@ function codeGenForParams(param: AbiParameter, index: number): string {
 
 function codeGenForArgs(param: AbiParameter, index: number): string {
   const paramName = param.name || `arg${index}`;
-  if (param.type instanceof ArrayType) return `${paramName}.map(val => val.toString())`;
+  if (param.type instanceof ArrayType) {
+    const elemParam = { name: `${paramName}Elem`, type: param.type.itemType };
+    return `${paramName}.map(${elemParam.name} => ${codeGenForArgs(elemParam, 0)})`;
+  }
   if (param.type instanceof BooleanType) return paramName;
   return `${paramName}.toString()`;
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-set -x
 cd "$(dirname "$0")"
 cd ..
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -x
 cd "$(dirname "$0")"
 cd ..
 

--- a/test/integration/contracts/DumbContract.sol
+++ b/test/integration/contracts/DumbContract.sol
@@ -67,6 +67,11 @@ contract DumbContract {
     return boolParam;
   }
 
+  function callWithBooleanArray(bool[] boolArrayParam) public pure returns (bool[]) {
+    boolArrayParam = boolArrayParam;
+    return boolArrayParam;
+  }
+
   function testAddress(address a) pure public returns (address) {
     return a;
   }

--- a/test/integration/targets/legacy/DumbContract.spec.ts
+++ b/test/integration/targets/legacy/DumbContract.spec.ts
@@ -195,6 +195,12 @@ describe("DumbContract", () => {
     expect(result).to.eq(byteString);
   });
 
+  it("should correctly pass both boolean values in args", async () => {
+    const dumbContract = await DumbContract.createAndValidate(web3, contractAddress);
+    expect(await dumbContract.callWithBoolean(true)).to.be.deep.eq(true);
+    expect(await dumbContract.callWithBoolean(false)).to.be.deep.eq(false);
+  });
+
   describe("estimateGas", () => {
     it("should work", async () => {
       const dumbContract = await DumbContract.createAndValidate(web3, contractAddress);

--- a/test/integration/targets/legacy/DumbContract.spec.ts
+++ b/test/integration/targets/legacy/DumbContract.spec.ts
@@ -197,8 +197,16 @@ describe("DumbContract", () => {
 
   it("should correctly pass both boolean values in args", async () => {
     const dumbContract = await DumbContract.createAndValidate(web3, contractAddress);
+
     expect(await dumbContract.callWithBoolean(true)).to.be.deep.eq(true);
     expect(await dumbContract.callWithBoolean(false)).to.be.deep.eq(false);
+  });
+
+  it("should correctly pass a boolean array argument", async () => {
+    const dumbContract = await DumbContract.createAndValidate(web3, contractAddress);
+    const array = [true, false];
+
+    expect(await dumbContract.callWithBooleanArray(array)).to.be.deep.eq(array);
   });
 
   describe("estimateGas", () => {
@@ -207,7 +215,7 @@ describe("DumbContract", () => {
 
       const estimatedGas = await dumbContract.countupTx(1).estimateGas({ from: accounts[0] });
 
-      expect(estimatedGas).to.be.eq(82683);
+      expect(estimatedGas).to.be.eq(82705);
     });
   });
 });


### PR DESCRIPTION
Fixes #120 

 * updated code generation for passing boolean arguments in methods
 * updated code generation for passing arrays, so nested boolean arguments work too
 * updated tests for the legacy target, to verify that boolean values are passed correctly