### PR TITLE
Feature/ethers contract returning

### DIFF
--- a/lib/targets/ethers/generation.ts
+++ b/lib/targets/ethers/generation.ts
@@ -22,18 +22,30 @@ import {
 } from "../../parser/typeParser";
 
 export function codegen(contract: Contract) {
+  // TODO strict typings for the event listener methods?
   const template = `
-  import { Contract, ContractTransaction, EventFilter } from 'ethers';
+  import { Contract, ContractTransaction, EventFilter, Listener, Signer } from 'ethers';
   import { Provider } from 'ethers/providers';
   import { BigNumber } from "ethers/utils";
   import { TransactionOverrides } from ".";
 
   export class ${contract.name} extends Contract {
+    connect(signerOrProvider: Signer | Provider | string): ${contract.name};
+    attach(addressOrName: string): ${contract.name};
+    deployed(): Promise<${contract.name}>;
+
+    on(event: EventFilter | string, listener: Listener): ${contract.name};
+    once(event: EventFilter | string, listener: Listener): ${contract.name};
+    addListener(eventName: EventFilter | string, listener: Listener): ${contract.name};
+    removeAllListeners(eventName: EventFilter | string): ${contract.name};
+    removeListener(eventName: any, listener: Listener): ${contract.name};
+
     functions: {
       ${contract.constantFunctions.map(generateConstantFunction).join("\n")}
       ${contract.functions.map(generateFunction).join("\n")}
       ${contract.constants.map(generateConstant).join("\n")}
     };
+
     filters: {
       ${contract.events.map(generateEvents).join("\n")}
     }

--- a/lib/targets/ethers/generation.ts
+++ b/lib/targets/ethers/generation.ts
@@ -24,8 +24,8 @@ import {
 export function codegen(contract: Contract) {
   // TODO strict typings for the event listener methods?
   const template = `
-  import { Contract, ContractTransaction, EventFilter, Listener, Signer } from 'ethers';
-  import { Provider } from 'ethers/providers';
+  import { Contract, ContractTransaction, EventFilter, Signer } from 'ethers';
+  import { Listener, Provider } from 'ethers/providers';
   import { BigNumber } from "ethers/utils";
   import { TransactionOverrides } from ".";
 
@@ -48,7 +48,11 @@ export function codegen(contract: Contract) {
 
     filters: {
       ${contract.events.map(generateEvents).join("\n")}
-    }
+    };
+
+    estimate: {
+      ${contract.functions.map(generateEstimateFunction).join("\n")}
+    };
 }
   `;
 
@@ -66,6 +70,12 @@ function generateFunction(fn: FunctionDeclaration): string {
   ${fn.name}(${generateInputTypes(
     fn.inputs,
   )}overrides?: TransactionOverrides): Promise<ContractTransaction>;
+`;
+}
+
+function generateEstimateFunction(fn: FunctionDeclaration): string {
+  return `
+  ${fn.name}(${generateInputTypes(fn.inputs)}): Promise<BigNumber>;
 `;
 }
 

--- a/lib/targets/ethers/generation.ts
+++ b/lib/targets/ethers/generation.ts
@@ -124,11 +124,7 @@ function generateOutputTypes(outputs: Array<AbiParameter>): string {
 }
 
 function generateParamTypes(params: Array<AbiParameter>): string {
-  return `[${
-    params
-      .map(param => generateInputType(param.type))
-      .join(", ")
-  }]`
+  return `[${params.map(param => generateInputType(param.type)).join(", ")}]`;
 }
 
 function generateEvents(event: EventDeclaration) {
@@ -144,7 +140,7 @@ function generateInterfaceEventDescription(event: EventDeclaration): string {
 }
 
 function generateEventTopicTypes(eventArgs: Array<EventArgDeclaration>): string {
-  return `[${eventArgs.map(generateEventArgType).join(", ")}]`
+  return `[${eventArgs.map(generateEventArgType).join(", ")}]`;
 }
 
 function generateEventTypes(eventArgs: EventArgDeclaration[]) {
@@ -161,9 +157,7 @@ function generateEventTypes(eventArgs: EventArgDeclaration[]) {
 }
 
 function generateEventArgType(eventArg: EventArgDeclaration): string {
-  return eventArg.isIndexed
-    ? `${generateInputType(eventArg.type)} | null`
-    : "null";
+  return eventArg.isIndexed ? `${generateInputType(eventArg.type)} | null` : "null";
 }
 
 function generateInputType(evmType: EvmType): string {

--- a/lib/targets/ethers/index.ts
+++ b/lib/targets/ethers/index.ts
@@ -1,4 +1,3 @@
-import { Contract } from "../../parser/abiParser";
 import { TsGeneratorPlugin, TContext, TFileDesc } from "ts-generator";
 import { join } from "path";
 import { extractAbi, parse } from "../../parser/abiParser";

--- a/lib/targets/ethers/index.ts
+++ b/lib/targets/ethers/index.ts
@@ -46,7 +46,7 @@ export class Ethers extends TsGeneratorPlugin {
       {
         path: join(this.outDirAbs, "index.d.ts"),
         contents: `
-        import { BigNumberish } from "ethers/utils";
+        import { BigNumberish, FunctionDescription } from "ethers/utils";
 
         export class TransactionOverrides {
           nonce?: BigNumberish | Promise<BigNumberish>;
@@ -54,6 +54,10 @@ export class Ethers extends TsGeneratorPlugin {
           gasPrice?: BigNumberish | Promise<BigNumberish>;
           value?: BigNumberish | Promise<BigNumberish>;
           chainId?: number | Promise<number>;
+        }
+
+        export interface TypedFunctionDescription<Args extends Array<any>> extends FunctionDescription {
+          encode(params: Args): string;
         }`,
       },
     ];

--- a/lib/targets/ethers/index.ts
+++ b/lib/targets/ethers/index.ts
@@ -46,7 +46,7 @@ export class Ethers extends TsGeneratorPlugin {
       {
         path: join(this.outDirAbs, "index.d.ts"),
         contents: `
-        import { BigNumberish, FunctionDescription } from "ethers/utils";
+        import { BigNumberish, EventDescription, FunctionDescription } from "ethers/utils";
 
         export class TransactionOverrides {
           nonce?: BigNumberish | Promise<BigNumberish>;
@@ -54,6 +54,10 @@ export class Ethers extends TsGeneratorPlugin {
           gasPrice?: BigNumberish | Promise<BigNumberish>;
           value?: BigNumberish | Promise<BigNumberish>;
           chainId?: number | Promise<number>;
+        }
+
+        export interface TypedEventDescription<Args extends Array<any>> extends EventDescription {
+          encodeTopics(params: Args): Array<string>;
         }
 
         export interface TypedFunctionDescription<Args extends Array<any>> extends FunctionDescription {

--- a/test/integration/targets/ethers/ethers.ts
+++ b/test/integration/targets/ethers/ethers.ts
@@ -1,6 +1,6 @@
 const ganache = require("ganache-cli");
 
-import { ethers, Contract, Signer } from "ethers";
+import { Contract, ContractFactory, Signer } from "ethers";
 import { JsonRpcProvider } from "ethers/providers";
 import { join } from "path";
 import { readFileSync } from "fs";
@@ -11,7 +11,7 @@ let server: any;
 export async function createNewBlockchain() {
   const server = ganache.server();
   server.listen(8545, () => {});
-  const provider = new ethers.providers.JsonRpcProvider();
+  const provider = new JsonRpcProvider();
   const signer = provider.getSigner(0);
   return { server, signer };
 }
@@ -29,7 +29,7 @@ export async function deployContract(contractName: string): Promise<Contract> {
   const bin = readFileSync(join(abiDirPath, contractName + ".bin"), "utf-8");
   const code = "0x" + bin;
 
-  const factory = new ethers.ContractFactory(abi, code, signer);
+  const factory = new ContractFactory(abi, code, signer);
 
   return factory.deploy();
 }


### PR DESCRIPTION
Closes #140 

Added typings for
* the contract methods that return a contract instance
* gas estimate methods
* function tx encoding methods
* event topics encoding methods

I wanted to make the event methods to be properly typed (in particular, have a variant where the arguments of the `listener` are fully typed) -- but it doesn't look simple, let's make a separate issue for that.