### PR TITLE
Add struct output types for ethers

### DIFF
--- a/lib/targets/ethers/generation.ts
+++ b/lib/targets/ethers/generation.ts
@@ -205,7 +205,7 @@ function generateOutputType(evmType: EvmType): string {
     case StringType:
       return "string";
     case TupleType:
-      return "object[]";
+      return generateTupleType(evmType as TupleType, generateOutputType);
 
     default:
       throw new Error(`Unrecognized type ${evmType}`);

--- a/test/integration/targets/ethers/ContractsWithStructs.spec.ts
+++ b/test/integration/targets/ethers/ContractsWithStructs.spec.ts
@@ -1,0 +1,49 @@
+import { deployContract } from "./ethers";
+import { ContractWithStructs } from "./types/ethers-contracts/ContractWithStructs";
+import { BigNumber } from "ethers/utils";
+import { expect } from "chai";
+
+describe("ContractWithStructs", () => {
+  it("should work", async () => {
+    const contract = (await deployContract("ContractWithStructs")) as ContractWithStructs;
+
+    const res = await contract.functions.getCounter(1);
+    expect(res).to.be.deep.eq(new BigNumber("1"));
+  });
+
+  it("should have an address", async () => {
+    const contract = (await deployContract("ContractWithStructs")) as ContractWithStructs;
+
+    expect(contract.address).to.be.string;
+  });
+
+  it("should return structs in output", async () => {
+    const contract = (await deployContract("ContractWithStructs")) as ContractWithStructs;
+
+    const output = await contract.functions.getStuff();
+    expect(output._person.height).to.be.deep.eq(new BigNumber("12"));
+    expect(output._person.name).to.be.eq("fred");
+  });
+
+  it("should accepts structs in input", async () => {
+    const contract = (await deployContract("ContractWithStructs")) as ContractWithStructs;
+
+    await contract.functions.setStuff(
+      { height: 10, name: "bob", account: contract.address },
+      {
+        counter: 7,
+        mother: { height: 8, name: "mary", account: contract.address },
+        father: { height: 12, name: "jim", account: contract.address },
+      },
+    );
+
+    const output = await contract.functions.getStuff();
+    expect(output._person.height).to.be.deep.eq(new BigNumber("10"));
+    expect(output._person.name).to.be.eq("bob");
+    expect(output._thing.counter).to.be.deep.eq(new BigNumber("7"));
+    expect(output._thing.mother.name).to.be.eq("mary");
+    expect(output._thing.mother.height).to.be.deep.eq(new BigNumber("8"));
+    expect(output._thing.father.name).to.be.eq("jim");
+    expect(output._thing.father.height).to.be.deep.eq(new BigNumber("12"));
+  });
+});


### PR DESCRIPTION
Closes #119 

Added typings & tests for struct return types in ethers.js. Seems like this was simply missed for ethers, looks like all other targets already support struct return types