### PR TITLE
add non transacting transaction calls and tests to truffle target

### DIFF
--- a/lib/targets/truffle/generation.ts
+++ b/lib/targets/truffle/generation.ts
@@ -76,9 +76,20 @@ export interface ${c.name}Instance extends Truffle.ContractInstance {
 
 function generateFunction(fn: ConstantFunctionDeclaration | FunctionDeclaration): string {
   return `
-  ${fn.name}(${generateInputTypes(
+  ${fn.name}: {
+    (${generateInputTypes(
+      fn.inputs,
+    )} txDetails?: Truffle.TransactionDetails): Promise<Truffle.TransactionResponse>;
+  call(${generateInputTypes(
     fn.inputs,
-  )} txDetails?: Truffle.TransactionDetails): Promise<Truffle.TransactionResponse>;
+  )} txDetails?: Truffle.TransactionDetails): Promise<${generateOutputTypes(fn.outputs)}>;
+  sendTransaction(${generateInputTypes(
+    fn.inputs,
+  )} txDetails?: Truffle.TransactionDetails): Promise<string>;
+  estimateGas(${generateInputTypes(
+    fn.inputs,
+  )} txDetails?: Truffle.TransactionDetails): Promise<number>;
+  }
 `;
 }
 

--- a/test/integration/targets/truffle/contracts/DumbContract.sol
+++ b/test/integration/targets/truffle/contracts/DumbContract.sol
@@ -32,6 +32,12 @@ contract DumbContract {
     counterArray.push(counter);
   }
 
+  function countupWithReturn(uint offset) public returns (uint256) {
+    counter += offset;
+    counterArray.push(counter);
+    return counter;
+  }
+
   function returnSigned(int offset) pure public returns (int) {
     return offset;
   }

--- a/test/integration/targets/truffle/test/DumbContract.ts
+++ b/test/integration/targets/truffle/test/DumbContract.ts
@@ -13,6 +13,36 @@ contract("DumbContract", ([deployer]) => {
     expect((await contract.returnAll()).map(x => x.toNumber())).to.be.deep.eq([0, 5]);
   });
 
+  // it("should allow function to be simulated with call", async () => {
+  //   const contract = await DumbContract.new(0, { from: deployer });
+
+  //   expect(DumbContract.contractName).to.be.a("string");
+
+  //   expect(contract.address).to.be.a("string");
+  //   expect((await contract.counterWithOffset(2)).toNumber()).to.be.eq(2);
+  //   expect((await contract.returnAll()).map(x => x.toNumber())).to.be.deep.eq([0, 5]);
+  // });
+
+  it("should estimate gas", async () => {
+    const contract = await DumbContract.new(0, { from: deployer });
+    expect(await contract.countup.estimateGas(2)).to.not.be.undefined;
+    expect(await contract.countup.estimateGas(2)).to.be.gt(20000);
+  });
+
+  it("should simulate transaction with call", async () => {
+    const contract = await DumbContract.new(0, { from: deployer });
+    expect(await contract.countupWithReturn.call(2)).to.not.be.undefined;
+    expect((await contract.countupWithReturn.call(2)).toNumber()).to.be.eq(2);
+    expect((await contract.counter()).toNumber()).to.be.eq(0);
+  });
+
+  it("should allow transactions to be sent with sendTransaction", async () => {
+    const contract = await DumbContract.new(0, { from: deployer });
+    expect(await contract.countup.sendTransaction(2)).to.not.be.undefined;
+    expect((await contract.countup.sendTransaction(2)).length).to.be.eq(66);
+    expect((await contract.counter()).toNumber()).to.be.eq(4);
+  });
+
   it("should allow to pass unsigned values in multiple ways", async () => {
     const contract = await DumbContract.new(0, { from: deployer });
 

--- a/test/integration/targets/truffle/test/DumbContract.ts
+++ b/test/integration/targets/truffle/test/DumbContract.ts
@@ -13,16 +13,6 @@ contract("DumbContract", ([deployer]) => {
     expect((await contract.returnAll()).map(x => x.toNumber())).to.be.deep.eq([0, 5]);
   });
 
-  // it("should allow function to be simulated with call", async () => {
-  //   const contract = await DumbContract.new(0, { from: deployer });
-
-  //   expect(DumbContract.contractName).to.be.a("string");
-
-  //   expect(contract.address).to.be.a("string");
-  //   expect((await contract.counterWithOffset(2)).toNumber()).to.be.eq(2);
-  //   expect((await contract.returnAll()).map(x => x.toNumber())).to.be.deep.eq([0, 5]);
-  // });
-
   it("should estimate gas", async () => {
     const contract = await DumbContract.new(0, { from: deployer });
     expect(await contract.countup.estimateGas(2)).to.not.be.undefined;


### PR DESCRIPTION
https://github.com/ethereum-ts/TypeChain/issues/104

I added call, sendTransaction and estimateGas methods to generation.ts for the truffle target

## Call
call returns the same output as sending the TX but no state changes are made

### Test
I checked the counter method after calling the simulated TX. 
I had to add another countup method to the smart contract which returned a uint to test the simulated return value.

## sendTransaction
sendTransaction returns the TX hash of the state changing method.

### Test
For this test I checked that the method returns a 66 length string.

## estimateGas
estimateGas returns an integer showing how much gas the simulated TX would use.

### Test
For this test I checked that the estimated gas is over the minimum 20k threshold. Could also just check that it is an int