### PR TITLE
[ethers] named arguments for function args encoding methods

### DIFF
--- a/lib/targets/ethers/generation.ts
+++ b/lib/targets/ethers/generation.ts
@@ -93,7 +93,9 @@ function generateEstimateFunction(fn: FunctionDeclaration): string {
 
 function generateInterfaceFunctionDescription(fn: FunctionDeclaration): string {
   return `
-  ${fn.name}: TypedFunctionDescription<${generateParamTypes(fn.inputs)}>;
+  ${fn.name}: TypedFunctionDescription<{ encode(${generateParamNames(
+    fn.inputs,
+  )}: ${generateParamTypes(fn.inputs)}): string; }>;
 `;
 }
 
@@ -127,6 +129,10 @@ function generateParamTypes(params: Array<AbiParameter>): string {
   return `[${params.map(param => generateInputType(param.type)).join(", ")}]`;
 }
 
+function generateParamNames(params: Array<AbiParameter | EventArgDeclaration>): string {
+  return `[${params.map(param => param.name).join(", ")}]`;
+}
+
 function generateEvents(event: EventDeclaration) {
   return `
   ${event.name}(${generateEventTypes(event.inputs)}): EventFilter;
@@ -135,7 +141,9 @@ function generateEvents(event: EventDeclaration) {
 
 function generateInterfaceEventDescription(event: EventDeclaration): string {
   return `
-  ${event.name}: TypedEventDescription<${generateEventTopicTypes(event.inputs)}>;
+  ${event.name}: TypedEventDescription<{ encodeTopics(${generateParamNames(
+    event.inputs,
+  )}: ${generateEventTopicTypes(event.inputs)}): string[]; }>;
 `;
 }
 

--- a/lib/targets/ethers/index.ts
+++ b/lib/targets/ethers/index.ts
@@ -55,13 +55,16 @@ export class Ethers extends TsGeneratorPlugin {
           chainId?: number | Promise<number>;
         }
 
-        export interface TypedEventDescription<Args extends Array<any>> extends EventDescription {
-          encodeTopics(params: Args): Array<string>;
+        export interface TypedEventDescription<T extends Pick<EventDescription, 'encodeTopics'>>
+        extends EventDescription {
+          encodeTopics: T['encodeTopics'];
         }
 
-        export interface TypedFunctionDescription<Args extends Array<any>> extends FunctionDescription {
-          encode(params: Args): string;
-        }`,
+        export interface TypedFunctionDescription<T extends Pick<FunctionDescription, 'encode'>>
+        extends FunctionDescription {
+          encode: T['encode'];
+        }
+        `,
       },
     ];
   }


### PR DESCRIPTION
The `interface.functions.fnName.encode` methods that I added in PR #154 were effectively typed as, for example, `encode(params: [string, string, string]): string`. Though typesafe, this wasn't really helpful in developement.

With this change, I'm overriding not only the arguments typing for `encode`, but the whole method, and destructuring the arguments so their original names are shown, for example: `encode([receiverAddress, signature, assetData]: [string, string, string]): string`. I believe this is the best we can do here -- because ethers accepts the arguments as an array here, we can't just normally list the arguments with names.

Same problem solved for `encodeTopics` method on `interface.events.eventName`.

No functionality or typing is changed, only the names are added.