### PR TITLE
[ethers] Generate contract factories

### DIFF
--- a/__snapshots__/DumbContract.spec.ts.js
+++ b/__snapshots__/DumbContract.spec.ts.js
@@ -211,7 +211,12 @@ export class DumbContract extends TC.TypeChainContract {
         stateMutability: "pure",
         type: "function",
       },
-      { inputs: [], payable: false, stateMutability: "nonpayable", type: "constructor" },
+      {
+        inputs: [{ name: "initialCounter", type: "uint256" }],
+        payable: false,
+        stateMutability: "nonpayable",
+        type: "constructor",
+      },
       {
         anonymous: false,
         inputs: [

--- a/lib/parser/abiParser.spec.ts
+++ b/lib/parser/abiParser.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from "chai";
-import {
-  extractAbi,
-  RawEventAbiDefinition,
-  parseEvent,
-  ensure0xPrefix,
-  extractBytecode,
-} from "./abiParser";
+
 import { MalformedAbiError } from "../utils/errors";
+import {
+  ensure0xPrefix,
+  extractAbi,
+  extractBytecode,
+  parseEvent,
+  RawEventAbiDefinition,
+} from "./abiParser";
 import { AddressType, UnsignedIntegerType } from "./typeParser";
 
 describe("extractAbi", () => {
@@ -43,16 +44,16 @@ describe("extractBytecode", () => {
     expect(extractBytecode(resultBytecode)).to.eq(resultBytecode);
   });
 
-  it("should return null for non-bytecode non-json input", () => {
-    expect(extractBytecode("surely-not-bytecode")).to.be.null;
+  it("should return undefined for non-bytecode non-json input", () => {
+    expect(extractBytecode("surely-not-bytecode")).to.be.undefined;
   });
 
-  it("should return null for simple abi without bytecode", () => {
-    expect(extractBytecode(`[{ "name": "piece" }]`)).to.be.null;
+  it("should return undefined for simple abi without bytecode", () => {
+    expect(extractBytecode(`[{ "name": "piece" }]`)).to.be.undefined;
   });
 
-  it("should return null for nested abi without bytecode", () => {
-    expect(extractBytecode(`{ "abi": [{ "name": "piece" }] }`)).to.be.null;
+  it("should return undefined for nested abi without bytecode", () => {
+    expect(extractBytecode(`{ "abi": [{ "name": "piece" }] }`)).to.be.undefined;
   });
 
   it("should return bytecode from nested abi (truffle style)", () => {
@@ -64,8 +65,8 @@ describe("extractBytecode", () => {
     expect(extractBytecode(inputJson)).to.eq(resultBytecode);
   });
 
-  it("should return null when nested abi bytecode is malformed", () => {
-    expect(extractBytecode(`{ "bytecode": "surely-not-bytecode" }`)).to.be.null;
+  it("should return undefined when nested abi bytecode is malformed", () => {
+    expect(extractBytecode(`{ "bytecode": "surely-not-bytecode" }`)).to.be.undefined;
   });
 });
 

--- a/lib/parser/abiParser.ts
+++ b/lib/parser/abiParser.ts
@@ -254,3 +254,33 @@ export function extractAbi(rawJson: string): RawAbiDefinition[] {
 
   throw new MalformedAbiError("Not a valid ABI");
 }
+
+export function extractBytecode(rawContents: string): string | null {
+  const bytecodeRegex = /^[0-9a-fA-F]+$/;
+  // First try to see if this is a .bin file with just the bytecode, otherwise a json
+  if (rawContents.match(bytecodeRegex)) return rawContents;
+
+  let json;
+  try {
+    json = JSON.parse(rawContents);
+  } catch {
+    return null;
+  }
+
+  if (!json) return null;
+
+  if (json.bytecode && json.bytecode.match(bytecodeRegex)) {
+    return json.bytecode;
+  }
+
+  if (
+    json.evm &&
+    json.evm.bytecode &&
+    json.evm.bytecode.object &&
+    json.evm.bytecode.object.match(bytecodeRegex)
+  ) {
+    return json.evm.bytecode.object;
+  }
+
+  return null;
+}

--- a/lib/parser/abiParser.ts
+++ b/lib/parser/abiParser.ts
@@ -256,9 +256,9 @@ export function extractAbi(rawJson: string): RawAbiDefinition[] {
 }
 
 export function extractBytecode(rawContents: string): string | null {
-  const bytecodeRegex = /^[0-9a-fA-F]+$/;
+  const bytecodeRegex = /^(0x)?([0-9a-fA-F][0-9a-fA-F])+$/;
   // First try to see if this is a .bin file with just the bytecode, otherwise a json
-  if (rawContents.match(bytecodeRegex)) return rawContents;
+  if (rawContents.match(bytecodeRegex)) return ensure0xPrefix(rawContents);
 
   let json;
   try {
@@ -270,7 +270,7 @@ export function extractBytecode(rawContents: string): string | null {
   if (!json) return null;
 
   if (json.bytecode && json.bytecode.match(bytecodeRegex)) {
-    return json.bytecode;
+    return ensure0xPrefix(json.bytecode);
   }
 
   if (
@@ -279,8 +279,13 @@ export function extractBytecode(rawContents: string): string | null {
     json.evm.bytecode.object &&
     json.evm.bytecode.object.match(bytecodeRegex)
   ) {
-    return json.evm.bytecode.object;
+    return ensure0xPrefix(json.evm.bytecode.object);
   }
 
   return null;
+}
+
+export function ensure0xPrefix(hexString: string): string {
+  if (hexString.startsWith("0x")) return hexString;
+  return "0x" + hexString;
 }

--- a/lib/parser/abiParser.ts
+++ b/lib/parser/abiParser.ts
@@ -1,7 +1,7 @@
 import debug from "../utils/debug";
-import { EvmType, EvmTypeComponent, VoidType, parseEvmType } from "./typeParser";
 import { MalformedAbiError } from "../utils/errors";
 import { logger } from "../utils/logger";
+import { EvmType, EvmTypeComponent, parseEvmType, VoidType } from "./typeParser";
 
 export interface AbiParameter {
   name: string;
@@ -255,7 +255,7 @@ export function extractAbi(rawJson: string): RawAbiDefinition[] {
   throw new MalformedAbiError("Not a valid ABI");
 }
 
-export function extractBytecode(rawContents: string): string | null {
+export function extractBytecode(rawContents: string): string | undefined {
   const bytecodeRegex = /^(0x)?([0-9a-fA-F][0-9a-fA-F])+$/;
   // First try to see if this is a .bin file with just the bytecode, otherwise a json
   if (rawContents.match(bytecodeRegex)) return ensure0xPrefix(rawContents);
@@ -264,10 +264,10 @@ export function extractBytecode(rawContents: string): string | null {
   try {
     json = JSON.parse(rawContents);
   } catch {
-    return null;
+    return undefined;
   }
 
-  if (!json) return null;
+  if (!json) return undefined;
 
   if (json.bytecode && json.bytecode.match(bytecodeRegex)) {
     return ensure0xPrefix(json.bytecode);
@@ -282,7 +282,7 @@ export function extractBytecode(rawContents: string): string | null {
     return ensure0xPrefix(json.evm.bytecode.object);
   }
 
-  return null;
+  return undefined;
 }
 
 export function ensure0xPrefix(hexString: string): string {

--- a/lib/targets/ethers/index.ts
+++ b/lib/targets/ethers/index.ts
@@ -1,8 +1,9 @@
 import { TsGeneratorPlugin, TContext, TFileDesc } from "ts-generator";
 import { join } from "path";
-import { extractAbi, parse } from "../../parser/abiParser";
-import { getFilename } from "../shared";
-import { codegen } from "./generation";
+import { extractAbi, parse, Contract, extractBytecode } from "../../parser/abiParser";
+import { getFilename, getFileExtension } from "../shared";
+import { codegenContractTypings, codegenContractFactory } from "./generation";
+import { Dictionary } from "ts-essentials";
 
 export interface IEthersCfg {
   outDir?: string;
@@ -14,6 +15,11 @@ export class Ethers extends TsGeneratorPlugin {
   name = "Ethers";
 
   private readonly outDirAbs: string;
+  private readonly contractCache: Dictionary<{
+    abi: any;
+    contract: Contract;
+  }> = {};
+  private readonly bytecodeCache: Dictionary<string> = {};
 
   constructor(ctx: TContext<IEthersCfg>) {
     super(ctx);
@@ -23,20 +29,73 @@ export class Ethers extends TsGeneratorPlugin {
     this.outDirAbs = join(cwd, rawConfig.outDir || DEFAULT_OUT_PATH);
   }
 
-  transformFile(file: TFileDesc): TFileDesc | void {
-    const abi = extractAbi(file.contents);
-    const isEmptyAbi = abi.length === 0;
-    if (isEmptyAbi) {
+  transformFile(file: TFileDesc): TFileDesc[] | void {
+    const fileExt = getFileExtension(file.path);
+
+    // For json files with both ABI and bytecode, both the contract typing and factory can be
+    // generated at once. For split files (.abi and .bin) we don't know in which order they will
+    // be transformed -- so we temporarily store whichever comes first, and generate the factory
+    // only when both ABI and bytecode are present.
+
+    // TODO we might want to add a configuration switch to control whether we want to generate the
+    // factories, or just contract type declarations.
+
+    if (fileExt === ".bin") {
+      return this.transformBinFile(file);
+    }
+
+    return this.transformAbiOrFullJsonFile(file);
+  }
+
+  transformBinFile(file: TFileDesc): TFileDesc[] | void {
+    const name = getFilename(file.path);
+    const bytecode = extractBytecode(file.contents);
+
+    if (!bytecode) {
       return;
     }
 
+    if (this.contractCache[name]) {
+      const { contract, abi } = this.contractCache[name];
+      return [this.genContractFactoryFile(contract, abi, bytecode)];
+    } else {
+      this.bytecodeCache[name] = bytecode;
+    }
+  }
+
+  transformAbiOrFullJsonFile(file: TFileDesc): TFileDesc[] | void {
     const name = getFilename(file.path);
+    const abi = extractAbi(file.contents);
+
+    if (abi.length === 0) {
+      return;
+    }
 
     const contract = parse(abi, name);
+    const bytecode = extractBytecode(file.contents) || this.bytecodeCache[name];
 
+    if (bytecode) {
+      return [
+        this.genContractTypingsFile(contract),
+        this.genContractFactoryFile(contract, abi, bytecode),
+      ];
+    } else {
+      this.contractCache[name] = { abi, contract };
+      return [this.genContractTypingsFile(contract)];
+    }
+  }
+
+  genContractTypingsFile(contract: Contract): TFileDesc {
     return {
-      path: join(this.outDirAbs, `${name}.d.ts`),
-      contents: codegen(contract),
+      path: join(this.outDirAbs, `${contract.name}.d.ts`),
+      contents: codegenContractTypings(contract),
+    };
+  }
+
+  genContractFactoryFile(contract: Contract, abi: any, bytecode: string) {
+    return {
+      path: join(this.outDirAbs, `${contract.name}Factory.ts`),
+      contents: codegenContractFactory(contract, abi, bytecode),
     };
   }
 

--- a/lib/targets/shared.ts
+++ b/lib/targets/shared.ts
@@ -8,3 +8,7 @@ export interface IContext {
 export function getFilename(path: string) {
   return parse(path).name;
 }
+
+export function getFileExtension(path: string) {
+  return parse(path).ext;
+}

--- a/test/integration/before.ts
+++ b/test/integration/before.ts
@@ -78,7 +78,7 @@ async function generateEthers(cwd: string, prettierCfg: any) {
   removeSync(join(__dirname, outDir));
 
   const rawConfig: TPluginCfg<ITypechainCfg> = {
-    files: "**/*.abi",
+    files: "**/*.{abi,bin}",
     target: "ethers",
     outDir,
   };

--- a/test/integration/contracts/DumbContract.sol
+++ b/test/integration/contracts/DumbContract.sol
@@ -9,8 +9,8 @@ contract DumbContract {
   bytes32 public byteArray;
   bytes public dynamicByteArray;
 
-  constructor() public {
-    counter = 0;
+  constructor(uint initialCounter) public {
+    counter = initialCounter;
     someAddress = msg.sender;
   }
 

--- a/test/integration/targets/ethers/ContractWithOverloads.spec.ts
+++ b/test/integration/targets/ethers/ContractWithOverloads.spec.ts
@@ -1,12 +1,12 @@
-import { deployContract } from "./ethers";
-import { ContractWithOverloads } from "./types/ethers-contracts/ContractWithOverloads";
+import { ContractWithOverloadsFactory } from "./types/ethers-contracts/ContractWithOverloadsFactory";
 import { BigNumber } from "ethers/utils";
 
 import { expect } from "chai";
+import { getTestSigner } from "./ethers";
 
 describe("ContractWithOverloads", () => {
   it("should work", async () => {
-    const contract = (await deployContract("ContractWithOverloads")) as ContractWithOverloads;
+    const contract = await new ContractWithOverloadsFactory(getTestSigner()).deploy();
 
     expect(await contract.functions.counter()).to.be.deep.eq(new BigNumber("0"));
   });

--- a/test/integration/targets/ethers/ContractsWithStructs.spec.ts
+++ b/test/integration/targets/ethers/ContractsWithStructs.spec.ts
@@ -1,24 +1,29 @@
-import { deployContract } from "./ethers";
 import { ContractWithStructs } from "./types/ethers-contracts/ContractWithStructs";
+import { ContractWithStructsFactory } from "./types/ethers-contracts/ContractWithStructsFactory";
 import { BigNumber } from "ethers/utils";
 import { expect } from "chai";
+import { getTestSigner } from "./ethers";
 
 describe("ContractWithStructs", () => {
+  function deployContractWithStructs(): Promise<ContractWithStructs> {
+    return new ContractWithStructsFactory(getTestSigner()).deploy();
+  }
+
   it("should work", async () => {
-    const contract = (await deployContract("ContractWithStructs")) as ContractWithStructs;
+    const contract = await deployContractWithStructs();
 
     const res = await contract.functions.getCounter(1);
     expect(res).to.be.deep.eq(new BigNumber("1"));
   });
 
   it("should have an address", async () => {
-    const contract = (await deployContract("ContractWithStructs")) as ContractWithStructs;
+    const contract = await deployContractWithStructs();
 
     expect(contract.address).to.be.string;
   });
 
   it("should return structs in output", async () => {
-    const contract = (await deployContract("ContractWithStructs")) as ContractWithStructs;
+    const contract = await deployContractWithStructs();
 
     const output = await contract.functions.getStuff();
     expect(output._person.height).to.be.deep.eq(new BigNumber("12"));
@@ -26,7 +31,7 @@ describe("ContractWithStructs", () => {
   });
 
   it("should accepts structs in input", async () => {
-    const contract = (await deployContract("ContractWithStructs")) as ContractWithStructs;
+    const contract = await deployContractWithStructs();
 
     await contract.functions.setStuff(
       { height: 10, name: "bob", account: contract.address },

--- a/test/integration/targets/ethers/DumbContract.spec.ts
+++ b/test/integration/targets/ethers/DumbContract.spec.ts
@@ -1,14 +1,15 @@
-import { getContractFactory } from "./ethers";
-import { DumbContract, DumbContractFactory } from "./types/ethers-contracts/DumbContract";
+import { DumbContract } from "./types/ethers-contracts/DumbContract";
+import { DumbContractFactory } from "./types/ethers-contracts/DumbContractFactory";
 import { BigNumber } from "ethers/utils";
 
 import { expect } from "chai";
 import { Event } from "ethers";
 import { arrayify } from "ethers/utils/bytes";
+import { getTestSigner } from "./ethers";
 
 describe("DumbContract", () => {
   function deployDumbContract(): Promise<DumbContract> {
-    const factory = getContractFactory("DumbContract") as DumbContractFactory;
+    const factory = new DumbContractFactory(getTestSigner());
     return factory.deploy(0);
   }
 
@@ -26,7 +27,7 @@ describe("DumbContract", () => {
   });
 
   it("should allow passing a contructor argument in multiple ways", async () => {
-    const factory = getContractFactory("DumbContract") as DumbContractFactory;
+    const factory = new DumbContractFactory(getTestSigner());
     const contract1 = await factory.deploy(42);
     expect(await contract1.functions.counter()).to.be.deep.eq(new BigNumber("42"));
     const contract2 = await factory.deploy("1234123412341234123");

--- a/test/integration/targets/ethers/ethers.ts
+++ b/test/integration/targets/ethers/ethers.ts
@@ -17,20 +17,20 @@ export async function createNewBlockchain() {
 }
 
 before(async () => {
-  const r = await createNewBlockchain();
-  signer = r.signer;
-  server = r.server;
+  ({ server, signer } = await createNewBlockchain());
 });
 
-export async function deployContract(contractName: string): Promise<Contract> {
+export function getContractFactory(contractName: string): ContractFactory {
   const abiDirPath = join(__dirname, "../../abis");
 
   const abi = JSON.parse(readFileSync(join(abiDirPath, contractName + ".abi"), "utf-8"));
   const bin = readFileSync(join(abiDirPath, contractName + ".bin"), "utf-8");
   const code = "0x" + bin;
+  return new ContractFactory(abi, code, signer);
+}
 
-  const factory = new ContractFactory(abi, code, signer);
-
+export async function deployContract(contractName: string): Promise<Contract> {
+  const factory = getContractFactory(contractName);
   return factory.deploy();
 }
 

--- a/test/integration/targets/ethers/ethers.ts
+++ b/test/integration/targets/ethers/ethers.ts
@@ -1,9 +1,7 @@
 const ganache = require("ganache-cli");
 
-import { Contract, ContractFactory, Signer } from "ethers";
+import { Signer } from "ethers";
 import { JsonRpcProvider } from "ethers/providers";
-import { join } from "path";
-import { readFileSync } from "fs";
 
 let signer: Signer;
 let server: any;
@@ -20,18 +18,8 @@ before(async () => {
   ({ server, signer } = await createNewBlockchain());
 });
 
-export function getContractFactory(contractName: string): ContractFactory {
-  const abiDirPath = join(__dirname, "../../abis");
-
-  const abi = JSON.parse(readFileSync(join(abiDirPath, contractName + ".abi"), "utf-8"));
-  const bin = readFileSync(join(abiDirPath, contractName + ".bin"), "utf-8");
-  const code = "0x" + bin;
-  return new ContractFactory(abi, code, signer);
-}
-
-export async function deployContract(contractName: string): Promise<Contract> {
-  const factory = getContractFactory(contractName);
-  return factory.deploy();
+export function getTestSigner(): Signer {
+  return signer;
 }
 
 after(async () => {

--- a/test/integration/targets/legacy/DumbContract.spec.ts
+++ b/test/integration/targets/legacy/DumbContract.spec.ts
@@ -14,7 +14,7 @@ describe("DumbContract", () => {
   let contractAddress: string;
 
   beforeEach(async () => {
-    contractAddress = (await deployContract("DumbContract")).address;
+    contractAddress = (await deployContract("DumbContract", 0)).address;
   });
 
   it("should snapshot generated code", () =>

--- a/test/integration/targets/web3-1.0.0/DumbContract.spec.web3.ts
+++ b/test/integration/targets/web3-1.0.0/DumbContract.spec.web3.ts
@@ -4,8 +4,12 @@ import { DumbContract } from "./types/web3-contracts/DumbContract";
 import { expect } from "chai";
 
 describe("DumbContract", () => {
+  function deployDumbContract(): Promise<DumbContract> {
+    return deployContract<DumbContract>("DumbContract", 0);
+  }
+
   it("should work", async () => {
-    const contract: DumbContract = await deployContract<DumbContract>("DumbContract");
+    const contract: DumbContract = await deployDumbContract();
 
     const res = await contract.methods.returnAll().call({ from: accounts[0] });
     expect(isBigNumber(res[0])).to.be.true;
@@ -15,13 +19,13 @@ describe("DumbContract", () => {
   });
 
   it("should have an address", async () => {
-    const contract = await deployContract<DumbContract>("DumbContract");
+    const contract = await deployDumbContract();
 
     expect(await contract.options.address).to.be.string;
   });
 
   it("should allow to pass unsigned values in multiple ways", async () => {
-    const contract = await deployContract<DumbContract>("DumbContract");
+    const contract = await deployDumbContract();
 
     await contract.methods.countup(2).send({ from: accounts[0] });
     const withNumber = await contract.methods.counter().call();
@@ -35,7 +39,7 @@ describe("DumbContract", () => {
   });
 
   it("should allow to pass signed values in multiple ways", async () => {
-    const contract = await deployContract<DumbContract>("DumbContract");
+    const contract = await deployDumbContract();
 
     const withNumber = await contract.methods.returnSigned(2).call();
     expect(isBigNumber(withNumber)).to.be.true;
@@ -47,7 +51,7 @@ describe("DumbContract", () => {
   });
 
   it("should allow to pass address values in multiple ways", async () => {
-    const contract = await deployContract<DumbContract>("DumbContract");
+    const contract = await deployDumbContract();
 
     expect(
       await contract.methods.testAddress("0x0000000000000000000000000000000000000123").call(),
@@ -55,7 +59,7 @@ describe("DumbContract", () => {
   });
 
   it("should allow to pass bytes values in multiple ways", async () => {
-    const contract = await deployContract<DumbContract>("DumbContract");
+    const contract = await deployDumbContract();
     const byteString = "0xabcd123456000000000000000000000000000000000000000000000000000000";
 
     await contract.methods.callWithBytes(byteString).send({ from: accounts[0] });
@@ -66,7 +70,7 @@ describe("DumbContract", () => {
   });
 
   it("should allow to pass Buffer for dynamic bytes array", async () => {
-    const contract = await deployContract<DumbContract>("DumbContract");
+    const contract = await deployDumbContract();
     const byteString = "0xabcd123456000000000000000000000000000000000000000000000000000000";
 
     await contract.methods.callWithDynamicByteArray(byteString).send({ from: accounts[0] });
@@ -77,14 +81,14 @@ describe("DumbContract", () => {
   });
 
   it("should allow to pass boolean values", async () => {
-    const contract = await deployContract<DumbContract>("DumbContract");
+    const contract = await deployDumbContract();
 
     const res = await contract.methods.callWithBoolean(true).call();
     expect(res).to.be.deep.eq(true);
   });
 
   it("should allow to pass numeric arrays values in multiple ways", async () => {
-    const contract = await deployContract<DumbContract>("DumbContract");
+    const contract = await deployDumbContract();
 
     const res = await contract.methods.callWithArray2(["1", 2]).call();
     expect(res.length).to.be.eq(2);
@@ -95,13 +99,13 @@ describe("DumbContract", () => {
   });
 
   it("should allow to pass strings ", async () => {
-    const contract = await deployContract<DumbContract>("DumbContract");
+    const contract = await deployDumbContract();
 
     expect(await contract.methods.testString("abc").call()).to.be.deep.eq("abc");
   });
 
   it("should allow to clone contracts ", async () => {
-    const contract = await deployContract<DumbContract>("DumbContract");
+    const contract = await deployDumbContract();
 
     const contractClone = await contract.clone();
 

--- a/test/integration/targets/web3-1.0.0/web3.ts
+++ b/test/integration/targets/web3-1.0.0/web3.ts
@@ -23,7 +23,7 @@ before(async () => {
   accounts = r.accounts;
 });
 
-export async function deployContract<T>(contractName: string): Promise<T> {
+export async function deployContract<T>(contractName: string, ...args: any[]): Promise<T> {
   const abiDirPath = join(__dirname, "../../abis");
 
   const abi = JSON.parse(readFileSync(join(abiDirPath, contractName + ".abi"), "utf-8"));
@@ -31,7 +31,7 @@ export async function deployContract<T>(contractName: string): Promise<T> {
   const code = "0x" + bin;
 
   const Contract = new web3.eth.Contract(abi);
-  const t = Contract.deploy({ arguments: [], data: code });
+  const t = Contract.deploy({ arguments: args, data: code });
 
   return (await (t.send({
     from: accounts[0],

--- a/test/integration/utils/web3Contracts.ts
+++ b/test/integration/utils/web3Contracts.ts
@@ -3,7 +3,10 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { ContractInstance } from "web3";
 
-export async function deployContract(contractName: string): Promise<ContractInstance> {
+export async function deployContract(
+  contractName: string,
+  ...args: any[]
+): Promise<ContractInstance> {
   return new Promise<ContractInstance>((resolve, reject) => {
     const dirPath = join(__dirname, "../abis");
 
@@ -14,6 +17,7 @@ export async function deployContract(contractName: string): Promise<ContractInst
     const contract = web3.eth.contract(abi);
 
     (contract as any).new(
+      ...args,
       { from: accounts[0], data: code, gas: GAS_LIMIT_STANDARD },
       (err: Error, contract: any) => {
         // this callback gets called multiple times


### PR DESCRIPTION
Fixes #137

ethers v5 beta doesn't look ready to be used yet, so I opted to solve #137 in TypeChain for the time being.

There are 2 options for this PR -- tell me what do you think.

### 1. Only a type declaration for the contract factories
(see only commit 11f380f)
In this variant, we keep the current behavior for ethers, where TypeChain only generates typings, with no runtime code whatsoever. This adds a simple `<ContractName>Factory` typing declaration, which helps to properly type constructor arguments for contract deployment -- but the ABI and bytecode must still be passed manually (usually re-reading the JSONs on disk).

### 2. Fully working contract factories
(full PR)
In this variant, we deviate a bit from the current behavior: the contract typing files are left as they are now, but TypeChain also generates a separate runtime `<ContractName>Factory` class, which extends ethers' `ContractFactory`, but has the ABI and bytecode built-in. Now, it's super easy to deploy contracts -- just instantiate the factory and pass the constructor arguments, no file operations needed.

We might want to add a CLI switch that enables/disables creation of the concrete factories (when off, it might generate the factory typings from first option instead). Is there a mechanism for "individual generator options", or would this have to be declared next to TypeChain's global CLI options?