### PR TITLE
[ethers] Factory for connecting to existing contract instances

### DIFF
--- a/__snapshots__/DumbContract.spec.ts.js
+++ b/__snapshots__/DumbContract.spec.ts.js
@@ -176,6 +176,15 @@ export class DumbContract extends TC.TypeChainContract {
         type: "function",
       },
       {
+        constant: true,
+        inputs: [],
+        name: "testVoidReturn",
+        outputs: [],
+        payable: false,
+        stateMutability: "pure",
+        type: "function",
+      },
+      {
         constant: false,
         inputs: [{ name: "dynamicBytes", type: "bytes" }],
         name: "callWithDynamicByteArray",
@@ -308,6 +317,10 @@ export class DumbContract extends TC.TypeChainContract {
 
   public counterWithOffset(offset: BigNumber | number): Promise<BigNumber> {
     return TC.promisify(this.rawWeb3Contract.counterWithOffset, [offset.toString()]);
+  }
+
+  public testVoidReturn(): Promise<void> {
+    return TC.promisify(this.rawWeb3Contract.testVoidReturn, []);
   }
 
   public countupForEtherTx(): TC.DeferredTransactionWrapper<TC.IPayableTxParams> {

--- a/lib/targets/ethers/generation.spec.ts
+++ b/lib/targets/ethers/generation.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from "chai";
+
+import { Contract } from "../../parser/abiParser";
+import { EvmType } from "../../parser/typeParser";
+import { codegenContractFactory, codegenContractTypings } from "./generation";
+
+class FakeEvmType extends EvmType {}
+
+describe("Ethers generation edge cases", () => {
+  const emptyContract: Contract = {
+    name: "TestContract",
+    constantFunctions: [],
+    constants: [],
+    functions: [],
+    events: [],
+    constructor: { inputs: [], payable: false },
+  };
+
+  it("should throw on invalid function input type", () => {
+    const contract: Contract = {
+      ...emptyContract,
+      constantFunctions: [
+        {
+          name: "testFunction",
+          inputs: [
+            {
+              name: "testInput",
+              type: new FakeEvmType(),
+            },
+          ],
+          outputs: [],
+        },
+      ],
+    };
+    expect(() => codegenContractTypings(contract)).to.throw("Unrecognized type FakeEvmType");
+  });
+
+  it("should throw on invalid function output type", () => {
+    const contract: Contract = {
+      ...emptyContract,
+      constantFunctions: [
+        {
+          name: "testFunction",
+          inputs: [],
+          outputs: [
+            {
+              name: "testOutput",
+              type: new FakeEvmType(),
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => codegenContractTypings(contract)).to.throw("Unrecognized type FakeEvmType");
+  });
+
+  it("should generate simple factory when no bytecode available", () => {
+    expect(codegenContractFactory(emptyContract, "abi", "")).to.match(
+      /export class TestContractFactory \{/,
+    );
+  });
+});

--- a/lib/targets/ethers/generation.ts
+++ b/lib/targets/ethers/generation.ts
@@ -262,7 +262,7 @@ function generateInputType(evmType: EvmType): string {
       return generateTupleType(evmType as TupleType, generateInputType);
 
     default:
-      throw new Error(`Unrecognized type ${evmType}`);
+      throw new Error(`Unrecognized type ${evmType.constructor.name}`);
   }
 }
 
@@ -289,7 +289,7 @@ function generateOutputType(evmType: EvmType): string {
       return generateTupleType(evmType as TupleType, generateOutputType);
 
     default:
-      throw new Error(`Unrecognized type ${evmType}`);
+      throw new Error(`Unrecognized type ${evmType.constructor.name}`);
   }
 }
 

--- a/lib/targets/ethers/generation.ts
+++ b/lib/targets/ethers/generation.ts
@@ -78,11 +78,20 @@ export function codegenContractFactory(contract: Contract, abi: any, bytecode: s
     : "";
   if (!bytecode) return codegenAbstractContractFactory(contract, abi);
 
+  // tsc with noUnusedLocals would complain about unused imports
+  const ethersUtilsImports: string[] = [];
+  if (constructorArgs.match(/: Arrayish/)) ethersUtilsImports.push("Arrayish");
+  if (constructorArgs.match(/: BigNumberish/)) ethersUtilsImports.push("BigNumberish");
+  const ethersUtilsImportLine =
+    ethersUtilsImports.length > 0
+      ? `import { ${ethersUtilsImports.join(", ")} } from "ethers/utils";`
+      : "";
+
   return `
   import { Contract, ContractFactory, Signer } from "ethers";
   import { Provider } from "ethers/providers";
-  import { Arrayish, BigNumberish } from "ethers/utils";
   import { UnsignedTransaction } from "ethers/utils/transaction";
+  ${ethersUtilsImportLine}
 
   import { ${contract.name} } from "./${contract.name}";
 

--- a/test/integration/contracts/DumbContract.sol
+++ b/test/integration/contracts/DumbContract.sol
@@ -91,6 +91,8 @@ contract DumbContract {
     return a;
   }
 
+  function testVoidReturn() pure public {}
+
   event Deposit(
     address indexed from,
     uint value

--- a/test/integration/targets/ethers/DumbContract.spec.ts
+++ b/test/integration/targets/ethers/DumbContract.spec.ts
@@ -1,11 +1,11 @@
-import { DumbContract } from "./types/ethers-contracts/DumbContract";
-import { DumbContractFactory } from "./types/ethers-contracts/DumbContractFactory";
-import { BigNumber } from "ethers/utils";
-
 import { expect } from "chai";
 import { Event } from "ethers";
+import { BigNumber } from "ethers/utils";
 import { arrayify } from "ethers/utils/bytes";
+
 import { getTestSigner } from "./ethers";
+import { DumbContract } from "./types/ethers-contracts/DumbContract";
+import { DumbContractFactory } from "./types/ethers-contracts/DumbContractFactory";
 
 describe("DumbContract", () => {
   function deployDumbContract(): Promise<DumbContract> {
@@ -34,6 +34,20 @@ describe("DumbContract", () => {
     expect(await contract2.functions.counter()).to.be.deep.eq(new BigNumber("1234123412341234123"));
     const contract3 = await factory.deploy(new BigNumber("5678567856785678567"));
     expect(await contract3.functions.counter()).to.be.deep.eq(new BigNumber("5678567856785678567"));
+  });
+
+  it("should allow connecting to an existing contract instance with signer or provider", async () => {
+    const contract1 = await new DumbContractFactory(getTestSigner()).deploy(42);
+    const contract2 = DumbContractFactory.connect(
+      contract1.address,
+      getTestSigner(),
+    );
+    expect(await contract2.functions.counter()).to.be.deep.eq(new BigNumber("42"));
+    const contract3 = DumbContractFactory.connect(
+      contract1.address,
+      getTestSigner().provider!,
+    );
+    expect(await contract3.functions.counter()).to.be.deep.eq(new BigNumber("42"));
   });
 
   it("should allow to pass unsigned values in multiple ways", async () => {


### PR DESCRIPTION
This is a follow-up for PR #160 (CC issue #137)

Problem: existing methods allowed only to deploy a new contract instance, or attach to an existing address, but only connecting through a complete `Signer` / `Wallet`. In actual use cases, you often don't need (or even _don't want_) the contract instance to have a signer connected, just a provider, to use contract's `view` or `pure` functions.

Proposed solution:
 * add to the contract factories: `static connect(address: string, signerOrProvider: Signer | Provider)` -- this just invokes the `Contract` constructor with the same params and the hardcoded ABI (since we can't add runtime functions to our contract type declarations)
 * for abstract contracts (or if bytecode was just not provided), generate a simplified version of the factory, containing just the above static method, without the usual deployment methods.