### PR TITLE
Add root level functions and constants for ethers

### DIFF
--- a/lib/targets/ethers/generation.ts
+++ b/lib/targets/ethers/generation.ts
@@ -57,6 +57,10 @@ export function codegenContractTypings(contract: Contract) {
       ${contract.constants.map(generateConstant).join("\n")}
     };
 
+    ${contract.constantFunctions.map(generateConstantFunction).join("\n")}
+    ${contract.functions.map(generateFunction).join("\n")}
+    ${contract.constants.map(generateConstant).join("\n")}
+
     filters: {
       ${contract.events.map(generateEvents).join("\n")}
     };


### PR DESCRIPTION
The ethers.js library exposes the contract's methods at the root level
in addition to being stored within the "function" mapping. This simply
duplicates the same available methods from the function mapping to the
root of the contract instance to match the actual behaviour of the
library.