### PR TITLE
[ethers] link internal libraries in factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ test/integration/targets/web3-v1/types/web3-contracts
 test/integration/targets/ethers/types/ethers-contracts
 test/package-test/types
 packages/core/README.md
+.vscode
+*.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@ test/integration/targets/web3-v1/types/web3-contracts
 test/integration/targets/ethers/types/ethers-contracts
 test/package-test/types
 packages/core/README.md
-.vscode
-*.code-workspace

--- a/packages/core/lib/parser/abiParser.spec.ts
+++ b/packages/core/lib/parser/abiParser.spec.ts
@@ -1,19 +1,19 @@
 import { expect } from "chai";
+import { merge } from "lodash";
 
 import { MalformedAbiError } from "../utils/errors";
 import {
   ensure0xPrefix,
   extractAbi,
   extractBytecode,
-  parseEvent,
-  RawEventAbiDefinition,
-  parse,
-  RawAbiDefinition,
   FunctionDeclaration,
   isConstant,
   isConstantFn,
+  parse,
+  parseEvent,
+  RawAbiDefinition,
+  RawEventAbiDefinition,
 } from "./abiParser";
-import { merge } from "lodash";
 
 describe("extractAbi", () => {
   it("should throw error on not JSON ABI", () => {
@@ -39,14 +39,14 @@ describe("extractAbi", () => {
 
 describe("extractBytecode", () => {
   const sampleBytecode = "1234abcd";
-  const resultBytecode = ensure0xPrefix(sampleBytecode);
+  const resultBytecode = { bytecode: ensure0xPrefix(sampleBytecode) };
 
   it("should return bytecode for bare bytecode string", () => {
-    expect(extractBytecode(sampleBytecode)).to.eq(resultBytecode);
+    expect(extractBytecode(sampleBytecode)).to.deep.eq(resultBytecode);
   });
 
   it("should return bytecode for bare bytecode with 0x prefix", () => {
-    expect(extractBytecode(resultBytecode)).to.eq(resultBytecode);
+    expect(extractBytecode(resultBytecode.bytecode)).to.deep.eq(resultBytecode);
   });
 
   it("should return undefined for non-bytecode non-json input", () => {
@@ -62,12 +62,12 @@ describe("extractBytecode", () => {
   });
 
   it("should return bytecode from nested abi (truffle style)", () => {
-    expect(extractBytecode(`{ "bytecode": "${sampleBytecode}" }`)).to.eq(resultBytecode);
+    expect(extractBytecode(`{ "bytecode": "${sampleBytecode}" }`)).to.deep.eq(resultBytecode);
   });
 
   it("should return bytecode from nested abi (ethers style)", () => {
     const inputJson = `{ "evm": { "bytecode": { "object": "${sampleBytecode}" }}}`;
-    expect(extractBytecode(inputJson)).to.eq(resultBytecode);
+    expect(extractBytecode(inputJson)).to.deep.eq(resultBytecode);
   });
 
   it("should return undefined when nested abi bytecode is malformed", () => {

--- a/packages/core/lib/parser/abiParser.spec.ts
+++ b/packages/core/lib/parser/abiParser.spec.ts
@@ -137,6 +137,17 @@ describe("extractBytecode with link references", () => {
       linkReferences: [linkRef4],
     });
   });
+
+  it("should still extract solc 0.5 link references when plain bytecode is also present", () => {
+    const bytecodeObj4a = {
+      ...bytecodeObj4,
+      bytecode: bytecodeObj4.evm.bytecode.object,
+    };
+    expect(extractBytecode(JSON.stringify(bytecodeObj4a))).to.be.deep.eq({
+      bytecode: bytecodeObj4.evm.bytecode.object,
+      linkReferences: [linkRef4],
+    });
+  });
 });
 
 describe("ensure0xPrefix", () => {

--- a/packages/core/lib/parser/abiParser.ts
+++ b/packages/core/lib/parser/abiParser.ts
@@ -280,10 +280,7 @@ export function extractBytecode(rawContents: string): BytecodeWithLinkReferences
 
   if (!json) return undefined;
 
-  if (json.bytecode && json.bytecode.match(bytecodeRegex)) {
-    return extractLinkReferences(json.bytecode);
-  }
-
+  // `json.evm.bytecode` often has more information than `json.bytecode`, needs to be checked first
   if (
     json.evm &&
     json.evm.bytecode &&
@@ -291,6 +288,10 @@ export function extractBytecode(rawContents: string): BytecodeWithLinkReferences
     json.evm.bytecode.object.match(bytecodeRegex)
   ) {
     return extractLinkReferences(json.evm.bytecode.object, json.evm.bytecode.linkReferences);
+  }
+
+  if (json.bytecode && json.bytecode.match(bytecodeRegex)) {
+    return extractLinkReferences(json.bytecode);
   }
 
   return undefined;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,7 @@
     "command-line-args": "^4.0.7",
     "debug": "^3.0.1",
     "fs-extra": "^7.0.0",
+    "js-sha3": "^0.8.0",
     "lodash": "^4.17.15",
     "ts-generator": "^0.0.8"
   },

--- a/packages/typechain-target-ethers/lib/generation.spec.ts
+++ b/packages/typechain-target-ethers/lib/generation.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
-
 import { Contract } from "typechain";
+
 import { codegenContractFactory } from "./generation";
 
 describe("Ethers generation edge cases", () => {
@@ -12,7 +12,7 @@ describe("Ethers generation edge cases", () => {
   };
 
   it("should generate simple factory when no bytecode available", () => {
-    expect(codegenContractFactory(emptyContract, "abi", "")).to.match(
+    expect(codegenContractFactory(emptyContract, "abi", undefined)).to.match(
       /export class TestContractFactory \{/,
     );
   });

--- a/packages/typechain-target-ethers/lib/index.ts
+++ b/packages/typechain-target-ethers/lib/index.ts
@@ -1,15 +1,15 @@
 import { join } from "path";
 import { Dictionary } from "ts-essentials";
 import { TContext, TFileDesc, TsGeneratorPlugin } from "ts-generator";
-
 import {
   Contract,
   extractAbi,
   extractBytecode,
-  parse,
   getFileExtension,
   getFilename,
+  parse,
 } from "typechain";
+
 import {
   codegenAbstractContractFactory,
   codegenContractFactory,
@@ -59,7 +59,7 @@ export default class Ethers extends TsGeneratorPlugin {
 
   transformBinFile(file: TFileDesc): TFileDesc[] | void {
     const name = getFilename(file.path);
-    const bytecode = extractBytecode(file.contents);
+    const { bytecode } = extractBytecode(file.contents) || {};
 
     if (!bytecode) {
       return;
@@ -83,7 +83,7 @@ export default class Ethers extends TsGeneratorPlugin {
     }
 
     const contract = parse(abi, name);
-    const bytecode = extractBytecode(file.contents) || this.bytecodeCache[name];
+    const bytecode = (extractBytecode(file.contents) || {}).bytecode || this.bytecodeCache[name];
 
     if (bytecode) {
       return [

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -e
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
 cd "$(dirname "$0")"
 cd ..
 

--- a/test/integration/contracts/ContractWithLibrary.sol
+++ b/test/integration/contracts/ContractWithLibrary.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.24;
+
+library TestLibrary {
+
+    function enhanceVal(uint256 _val) public pure returns (uint256) {
+        return _val + 42;
+    }
+
+}
+
+contract ContractWithLibrary {
+
+    uint256 public val;
+
+    function setVal(uint256 _val) public {
+        val = TestLibrary.enhanceVal(TestLibrary.enhanceVal(_val));
+    }
+
+}

--- a/test/integration/targets/ethers/ContractWithLibrary.spec.ts
+++ b/test/integration/targets/ethers/ContractWithLibrary.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+
+import { getTestSigner } from './ethers';
+import { ContractWithLibrary } from './types/ethers-contracts/ContractWithLibrary';
+import {
+    ContractWithLibraryFactory,
+    ContractWithLibraryLibraryAddresses,
+} from './types/ethers-contracts/ContractWithLibraryFactory';
+import { TestLibrary } from './types/ethers-contracts/TestLibrary';
+import { TestLibraryFactory } from './types/ethers-contracts/TestLibraryFactory';
+
+describe("ContractWithLibrary", () => {
+
+  let testLibrary: TestLibrary;
+  let contract: ContractWithLibrary;
+
+  it("should deploy the test library", async () => {
+    const factory = new TestLibraryFactory(getTestSigner());
+    testLibrary = await factory.deploy();
+    expect(testLibrary.address).to.match(/^0x[0-9a-fA-F]{40}$/);
+  });
+
+  it("should check the library works", async () => {
+    expect((await testLibrary.enhanceVal(0)).toNumber()).to.eq(42);
+  });
+
+  it("should link contract bytecode", () => {
+    const linkedBytecode = ContractWithLibraryFactory.linkBytecode({
+      "__./ContractWithLibrary.sol:TestLibrar__": testLibrary.address,
+    });
+    expect(linkedBytecode).to.match(/^0x[0-9a-f]{100,}$/);  // no more link placeholders
+    const trimmedLibraryAddress = testLibrary.address.replace(/^0x/, "").toLowerCase();
+    const matchedAddresses = linkedBytecode.match(new RegExp(trimmedLibraryAddress, "g"));
+    expect(matchedAddresses).not.to.be.undefined;
+    expect(matchedAddresses!.length).to.eq(2);
+  });
+
+  it("should deploy the contract with the library linked", async () => {
+    const linkAddresses: ContractWithLibraryLibraryAddresses = {
+      "__./ContractWithLibrary.sol:TestLibrar__": testLibrary.address,
+    };
+    const factory = new ContractWithLibraryFactory(linkAddresses, getTestSigner());
+    contract = await factory.deploy();
+    expect(contract.address).to.match(/^0x[0-9a-fA-F]{40}$/);
+  });
+
+  it("should check the contract using the library works", async () => {
+    await contract.setVal(336);
+    expect((await contract.val()).toNumber()).to.eq(420);
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2677,6 +2677,11 @@ js-sha3@^0.6.1:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.6.1.tgz#5b89f77a7477679877f58c4a075240934b1f95c0"
   integrity sha1-W4n3enR3Z5h39YxKB1JAk0sflcA=
 
+js-sha3@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"


### PR DESCRIPTION
* closes #177 
* the parser also extracts references to unlinked libraries from the bytecode.
* if the contract json contains the `evm.bytecode.linkReferences` (which is the case e.g. when using [waffle](https://github.com/EthWorks/Waffle)), its contents are used to get human understandable keys for the library addresses object (ie. `contracts/file.sol:SomeContract` instead of a partial hash).
* the generated contract factory for `ethers` target will have another param to specify addresses of the libraries to be linked.
* other targets don't generate factories for now, but if they do, they will be able to use the updated parser `extractBytecode` function to easily implement similar linking feature.
* NOTE: the base for this PR is `kk/parser-rewrite` for easier review. It should be changed to `master` once #172 is merged.


EDIT by krzkaczor:
Closes https://github.com/ethereum-ts/TypeChain/issues/125