### PR TITLE
Handle absolute paths in outDir

### DIFF
--- a/packages/typechain-target-ethers/lib/index.ts
+++ b/packages/typechain-target-ethers/lib/index.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join, resolve } from "path";
 import { Dictionary } from "ts-essentials";
 import { TContext, TFileDesc, TsGeneratorPlugin } from "ts-generator";
 import {
@@ -38,7 +38,7 @@ export default class Ethers extends TsGeneratorPlugin {
 
     const { cwd, rawConfig } = ctx;
 
-    this.outDirAbs = join(cwd, rawConfig.outDir || DEFAULT_OUT_PATH);
+    this.outDirAbs = resolve(cwd, rawConfig.outDir || DEFAULT_OUT_PATH);
   }
 
   transformFile(file: TFileDesc): TFileDesc[] | void {

--- a/packages/typechain-target-truffle/lib/index.ts
+++ b/packages/typechain-target-truffle/lib/index.ts
@@ -1,6 +1,6 @@
 import { Contract, getFilename, extractAbi, parse } from "typechain";
 import { TsGeneratorPlugin, TContext, TFileDesc } from "ts-generator";
-import { join } from "path";
+import { join, resolve } from "path";
 
 import { codegen, generateArtifactHeaders } from "./generation";
 
@@ -21,7 +21,7 @@ export default class Truffle extends TsGeneratorPlugin {
 
     const { cwd, rawConfig } = ctx;
 
-    this.outDirAbs = join(cwd, rawConfig.outDir || DEFAULT_OUT_PATH);
+    this.outDirAbs = resolve(cwd, rawConfig.outDir || DEFAULT_OUT_PATH);
   }
 
   transformFile(file: TFileDesc): TFileDesc | void {

--- a/packages/typechain-target-web3-v1/lib/index.ts
+++ b/packages/typechain-target-web3-v1/lib/index.ts
@@ -1,5 +1,5 @@
 import { TsGeneratorPlugin, TContext, TFileDesc } from "ts-generator";
-import { join } from "path";
+import { join, resolve } from "path";
 import { extractAbi, parse, getFilename } from "typechain";
 import { codegen } from "./generation";
 
@@ -19,7 +19,7 @@ export default class Web3 extends TsGeneratorPlugin {
 
     const { cwd, rawConfig } = ctx;
 
-    this.outDirAbs = join(cwd, rawConfig.outDir || DEFAULT_OUT_PATH);
+    this.outDirAbs = resolve(cwd, rawConfig.outDir || DEFAULT_OUT_PATH);
   }
 
   transformFile(file: TFileDesc): TFileDesc | void {


### PR DESCRIPTION
The previous implementation joined the user-provided outDir with the working
directory. This meant that an absolute path as an outDir would get concatenated
to the working dir. Using path.resolve instead handles both absolute and
relative paths properly.

```
> resolve(process.cwd(), '/foo')
'/foo'
> resolve(process.cwd(), 'foo')
'/home/spalladino/Projects/TypeChain/foo'
> resolve(process.cwd(), './foo')
'/home/spalladino/Projects/TypeChain/foo'
```