### PR TITLE
 typechain-target-ethers: fixed peerDependency warning appearing during `yarn install`

### DIFF
--- a/packages/typechain-target-ethers/package.json
+++ b/packages/typechain-target-ethers/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.15"
   },
   "peerDependencies": {
-    "typechain": "1.0.0^"
+    "typechain": "^1.0.0"
   },
   "scripts": {
     "build": "rm -rf ./dist && cp -R '../../dist/typechain-target-ethers/lib' ./dist/",


### PR DESCRIPTION
`warning " > typechain-target-ethers@1.0.2" has incorrect peer dependency "typechain@1.0.0^"`
now whould not appear anymore when using `yarn install`