### PR TITLE
typechain-target-truffle: fixed peerDependency warning appearing during `yarn install`

### DIFF
--- a/packages/typechain-target-truffle/package.json
+++ b/packages/typechain-target-truffle/package.json
@@ -18,7 +18,7 @@
     "lodash": "^4.17.15"
   },
   "peerDependencies": {
-    "typechain": "1.0.0^"
+    "typechain": "^1.0.0"
   },
   "scripts": {
     "build": "rm -rf ./dist && cp -R '../../dist/typechain-target-truffle/lib' ./dist/",


### PR DESCRIPTION
now
`warning " > typechain-target-truffle@1.0.1" has incorrect peer dependency "typechain@1.0.0^".`
Will not appar anymore, as the peerDependency is now specifying correct version