### PR TITLE
typechain-target-web3-v1: fixed peerDependency warning appearing during `yarn install`

### DIFF
--- a/packages/typechain-target-web3-v1/package.json
+++ b/packages/typechain-target-web3-v1/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.15"
   },
   "peerDependencies": {
-    "typechain": "1.0.0^"
+    "typechain": "^1.0.0"
   },
   "scripts": {
     "build": "rm -rf ./dist && cp -R '../../dist/typechain-target-web3-v1/lib' ./dist/",


### PR DESCRIPTION
Now
`warning " > typechain-target-web3-v1@1.0.1" has incorrect peer dependency "typechain@1.0.0^".`
Will not appar anymore, as the peerDependency is now specifying correct version