### PR TITLE
do not throw on unrecognized ABI elements

### DIFF
--- a/packages/core/lib/parser/abiParser.ts
+++ b/packages/core/lib/parser/abiParser.ts
@@ -137,7 +137,7 @@ export function parse(abi: Array<RawAbiDefinition>, name: string): Contract {
       return;
     }
 
-    throw new Error(`Unrecognized abi element: ${abiPiece.type}`);
+    debug(`Unrecognized abi element: ${abiPiece.type}`);
   });
 
   return {


### PR DESCRIPTION
Tmp fix for: https://github.com/ethereum-ts/TypeChain/issues/209