### PR TITLE
Use raw names for `artifacts.require`

### DIFF
--- a/packages/target-truffle-v4/src/codegen/headers.ts
+++ b/packages/target-truffle-v4/src/codegen/headers.ts
@@ -7,7 +7,7 @@ export function codegenArtifactHeaders(contracts: Contract[]): string {
   declare global {
     namespace Truffle {
       interface Artifacts {
-        ${contracts.map((c) => `require(name: "${c.name}"): ${c.name}Contract;`).join('\n')}
+        ${contracts.map((c) => `require(name: "${c.rawName}"): ${c.name}Contract;`).join('\n')}
       }
     }
   }

--- a/packages/target-truffle-v5/src/codegen/headers.ts
+++ b/packages/target-truffle-v5/src/codegen/headers.ts
@@ -7,7 +7,7 @@ export function codegenArtifactHeaders(contracts: Contract[]): string {
   declare global {
     namespace Truffle {
       interface Artifacts {
-        ${contracts.map((c) => `require(name: "${c.name}"): ${c.name}Contract;`).join('\n')}
+        ${contracts.map((c) => `require(name: "${c.rawName}"): ${c.name}Contract;`).join('\n')}
       }
     }
   }


### PR DESCRIPTION
As far as I can tell, Truffle's `artifacts.require` should use the `rawName` rather than the normalized `name`. e.g. a contract named `ERC20` won't be found when `require`d as `Erc20`.