### PR TITLE
Export contract types in artifact headers

### DIFF
--- a/packages/target-truffle-v4-test/types/truffle-contracts/index.d.ts
+++ b/packages/target-truffle-v4-test/types/truffle-contracts/index.d.ts
@@ -20,3 +20,13 @@ declare global {
     }
   }
 }
+
+export {
+  DataTypesInputContract,
+  DataTypesInputInstance
+} from "./DataTypesInput";
+export { DataTypesPureContract, DataTypesPureInstance } from "./DataTypesPure";
+export { DataTypesViewContract, DataTypesViewInstance } from "./DataTypesView";
+export { EventsContract, EventsInstance } from "./Events";
+export { OverloadsContract, OverloadsInstance } from "./Overloads";
+export { PayableContract, PayableInstance } from "./Payable";

--- a/packages/target-truffle-v4/src/codegen/headers.ts
+++ b/packages/target-truffle-v4/src/codegen/headers.ts
@@ -11,5 +11,7 @@ export function codegenArtifactHeaders(contracts: Contract[]): string {
       }
     }
   }
+
+  ${contracts.map((c) => `export {${c.name}Contract, ${c.name}Instance} from "./${c.name}";`).join('\n')}
   `
 }

--- a/packages/target-truffle-v5-test/types/truffle-contracts/index.d.ts
+++ b/packages/target-truffle-v5-test/types/truffle-contracts/index.d.ts
@@ -20,3 +20,13 @@ declare global {
     }
   }
 }
+
+export {
+  DataTypesInputContract,
+  DataTypesInputInstance
+} from "./DataTypesInput";
+export { DataTypesPureContract, DataTypesPureInstance } from "./DataTypesPure";
+export { DataTypesViewContract, DataTypesViewInstance } from "./DataTypesView";
+export { EventsContract, EventsInstance } from "./Events";
+export { OverloadsContract, OverloadsInstance } from "./Overloads";
+export { PayableContract, PayableInstance } from "./Payable";

--- a/packages/target-truffle-v5/src/codegen/headers.ts
+++ b/packages/target-truffle-v5/src/codegen/headers.ts
@@ -11,5 +11,7 @@ export function codegenArtifactHeaders(contracts: Contract[]): string {
       }
     }
   }
+
+  ${contracts.map((c) => `export {${c.name}Contract, ${c.name}Instance} from "./${c.name}";`).join('\n')}
   `
 }


### PR DESCRIPTION
This PR changes the codegen for the Truffle artifact headers such that the contracts (and now, also contract instances) are exported and imported.

The use-case for this is the ease of importing multiple contracts from one location. I believe this was also the behaviour of TypeChain v1. Alternatively, this could also be done with a separate, optional file; but ideally this is done with TypeChain rather than in userland.

It seems as if the `no-unused-vars` eslint rule is violated in the generated files, so I'm not sure if there's a better solution here. `ts-generator` could also add `eslint-disable`, or maybe there's a neater solution.