### PR TITLE
Fix incorrect return type for contract.at()

### DIFF
--- a/packages/target-truffle-v4-test/types/truffle-contracts/types.d.ts
+++ b/packages/target-truffle-v4-test/types/truffle-contracts/types.d.ts
@@ -82,7 +82,7 @@ declare namespace Truffle {
 
   interface Contract<T> extends ContractNew<any[]> {
     deployed(): Promise<T>;
-    at(address: string): T;
+    at(address: string): Promise<T>;
     address: string;
     contractName: string;
   }

--- a/packages/target-truffle-v4/static/types.d.ts
+++ b/packages/target-truffle-v4/static/types.d.ts
@@ -71,7 +71,7 @@ declare namespace Truffle {
 
   interface Contract<T> extends ContractNew<any[]> {
     deployed(): Promise<T>
-    at(address: string): T
+    at(address: string): Promise<T>
     address: string
     contractName: string
   }

--- a/packages/target-truffle-v5-test/types/truffle-contracts/types.d.ts
+++ b/packages/target-truffle-v5-test/types/truffle-contracts/types.d.ts
@@ -82,7 +82,7 @@ declare namespace Truffle {
 
   interface Contract<T> extends ContractNew<any[]> {
     deployed(): Promise<T>;
-    at(address: string): T;
+    at(address: string): Promise<T>;
     address: string;
     contractName: string;
   }

--- a/packages/target-truffle-v5/static/types.d.ts
+++ b/packages/target-truffle-v5/static/types.d.ts
@@ -71,7 +71,7 @@ declare namespace Truffle {
 
   interface Contract<T> extends ContractNew<any[]> {
     deployed(): Promise<T>
-    at(address: string): T
+    at(address: string): Promise<T>
     address: string
     contractName: string
   }


### PR DESCRIPTION
`at()` is an asynchronous function that returns a promise.

v5: https://github.com/trufflesuite/truffle/blob/693b413f3507ca4cf0fb9c1cb02ef04665b3a945/packages/contract/lib/contract/constructorMethods.js#L60

v4: https://github.com/trufflesuite/truffle/blob/v4.1.17/packages/truffle-contract/contract.js#L427