### PR TITLE
Add link method to contract constructor

### DIFF
--- a/packages/target-truffle-v4-test/types/truffle-contracts/types.d.ts
+++ b/packages/target-truffle-v4-test/types/truffle-contracts/types.d.ts
@@ -83,6 +83,8 @@ declare namespace Truffle {
   interface Contract<T> extends ContractNew<any[]> {
     deployed(): Promise<T>;
     at(address: string): Promise<T>;
+    link(name: string, address: string): void;
+    link<U>(contract: Contract<U>): void;
     address: string;
     contractName: string;
   }

--- a/packages/target-truffle-v4/static/types.d.ts
+++ b/packages/target-truffle-v4/static/types.d.ts
@@ -72,6 +72,8 @@ declare namespace Truffle {
   interface Contract<T> extends ContractNew<any[]> {
     deployed(): Promise<T>
     at(address: string): Promise<T>
+    link(name: string, address: string): void
+    link<U>(contract: Contract<U>): void
     address: string
     contractName: string
   }

--- a/packages/target-truffle-v5-test/types/truffle-contracts/types.d.ts
+++ b/packages/target-truffle-v5-test/types/truffle-contracts/types.d.ts
@@ -83,6 +83,8 @@ declare namespace Truffle {
   interface Contract<T> extends ContractNew<any[]> {
     deployed(): Promise<T>;
     at(address: string): Promise<T>;
+    link(name: string, address: string): void;
+    link<U>(contract: Contract<U>): void;
     address: string;
     contractName: string;
   }

--- a/packages/target-truffle-v5/static/types.d.ts
+++ b/packages/target-truffle-v5/static/types.d.ts
@@ -72,6 +72,8 @@ declare namespace Truffle {
   interface Contract<T> extends ContractNew<any[]> {
     deployed(): Promise<T>
     at(address: string): Promise<T>
+    link(name: string, address: string): void
+    link<U>(contract: Contract<U>): void
     address: string
     contractName: string
   }


### PR DESCRIPTION
link() is used to link libraries to contracts.

```js
const mylib = await MyLib.new()
MyContract.link("MyLib", mylib.address)
const myContract = await MyContract.new()
```

Truffle v4:
https://github.com/trufflesuite/truffle/blob/v4.1.17/packages/truffle-contract/contract.js#L564

Truffle v5:
https://github.com/trufflesuite/truffle/blob/981e421e771aab4a018151093c5e40d3f1ec2176/packages/contract/lib/contract/constructorMethods.js#L157