### PR TITLE
Fix target-ethers-v4 to allow transaction and contract call overrides 

### DIFF
--- a/packages/target-ethers-v4-test/test/Overload.test.ts
+++ b/packages/target-ethers-v4-test/test/Overload.test.ts
@@ -16,11 +16,16 @@ describe('Overloads', () => {
   afterEach(() => ganache.close())
 
   it('works with 1st overload', async () => {
-    const result = await contract.functions['overload1(int256)'](1)
+    const result = await contract['overload1(int256)'](1)
     typedAssert(result, new BigNumber(1))
   })
 
   it('works with 2n overload', async () => {
+    const result = await contract['overload1(uint256,uint256)'](1, 2)
+    typedAssert(result, new BigNumber(3))
+  })
+
+  it('works when calling the contract.functions version', async () => {
     const result = await contract.functions['overload1(uint256,uint256)'](1, 2)
     typedAssert(result, new BigNumber(3))
   })

--- a/packages/target-ethers-v4-test/types/DataTypesInput.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesInput.d.ts
@@ -87,32 +87,70 @@ export class DataTypesInput extends Contract {
   interface: DataTypesInputInterface;
 
   functions: {
-    input_address(input1: string): Promise<string>;
+    input_address(
+      input1: string
+    ): Promise<{
+      0: string;
+    }>;
 
-    input_bool(input1: boolean): Promise<boolean>;
+    input_bool(
+      input1: boolean
+    ): Promise<{
+      0: boolean;
+    }>;
 
-    input_bytes(input1: Arrayish): Promise<string>;
+    input_bytes(
+      input1: Arrayish
+    ): Promise<{
+      0: string;
+    }>;
 
-    input_bytes1(input1: Arrayish): Promise<string>;
+    input_bytes1(
+      input1: Arrayish
+    ): Promise<{
+      0: string;
+    }>;
 
-    input_enum(input1: BigNumberish): Promise<number>;
+    input_enum(
+      input1: BigNumberish
+    ): Promise<{
+      0: number;
+    }>;
 
-    input_int256(input1: BigNumberish): Promise<BigNumber>;
+    input_int256(
+      input1: BigNumberish
+    ): Promise<{
+      0: BigNumber;
+    }>;
 
-    input_int8(input1: BigNumberish): Promise<number>;
+    input_int8(
+      input1: BigNumberish
+    ): Promise<{
+      0: number;
+    }>;
 
-    input_stat_array(input1: BigNumberish[]): Promise<number[]>;
+    input_stat_array(
+      input1: BigNumberish[]
+    ): Promise<{
+      0: number[];
+    }>;
 
-    input_string(input1: string): Promise<string>;
+    input_string(
+      input1: string
+    ): Promise<{
+      0: string;
+    }>;
 
     input_struct(input1: {
       uint256_0: BigNumberish;
       uint256_1: BigNumberish;
     }): Promise<{
-      uint256_0: BigNumber;
-      uint256_1: BigNumber;
-      0: BigNumber;
-      1: BigNumber;
+      0: {
+        uint256_0: BigNumber;
+        uint256_1: BigNumber;
+        0: BigNumber;
+        1: BigNumber;
+      };
     }>;
 
     input_tuple(
@@ -123,9 +161,17 @@ export class DataTypesInput extends Contract {
       1: BigNumber;
     }>;
 
-    input_uint256(input1: BigNumberish): Promise<BigNumber>;
+    input_uint256(
+      input1: BigNumberish
+    ): Promise<{
+      0: BigNumber;
+    }>;
 
-    input_uint8(input1: BigNumberish): Promise<number>;
+    input_uint8(
+      input1: BigNumberish
+    ): Promise<{
+      0: number;
+    }>;
   };
 
   input_address(input1: string): Promise<string>;

--- a/packages/target-ethers-v4-test/types/DataTypesInput.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesInput.d.ts
@@ -87,70 +87,32 @@ export class DataTypesInput extends Contract {
   interface: DataTypesInputInterface;
 
   functions: {
-    input_address(
-      input1: string
-    ): Promise<{
-      0: string;
-    }>;
+    input_address(input1: string): Promise<string>;
 
-    input_bool(
-      input1: boolean
-    ): Promise<{
-      0: boolean;
-    }>;
+    input_bool(input1: boolean): Promise<boolean>;
 
-    input_bytes(
-      input1: Arrayish
-    ): Promise<{
-      0: string;
-    }>;
+    input_bytes(input1: Arrayish): Promise<string>;
 
-    input_bytes1(
-      input1: Arrayish
-    ): Promise<{
-      0: string;
-    }>;
+    input_bytes1(input1: Arrayish): Promise<string>;
 
-    input_enum(
-      input1: BigNumberish
-    ): Promise<{
-      0: number;
-    }>;
+    input_enum(input1: BigNumberish): Promise<number>;
 
-    input_int256(
-      input1: BigNumberish
-    ): Promise<{
-      0: BigNumber;
-    }>;
+    input_int256(input1: BigNumberish): Promise<BigNumber>;
 
-    input_int8(
-      input1: BigNumberish
-    ): Promise<{
-      0: number;
-    }>;
+    input_int8(input1: BigNumberish): Promise<number>;
 
-    input_stat_array(
-      input1: BigNumberish[]
-    ): Promise<{
-      0: number[];
-    }>;
+    input_stat_array(input1: BigNumberish[]): Promise<number[]>;
 
-    input_string(
-      input1: string
-    ): Promise<{
-      0: string;
-    }>;
+    input_string(input1: string): Promise<string>;
 
     input_struct(input1: {
       uint256_0: BigNumberish;
       uint256_1: BigNumberish;
     }): Promise<{
-      0: {
-        uint256_0: BigNumber;
-        uint256_1: BigNumber;
-        0: BigNumber;
-        1: BigNumber;
-      };
+      uint256_0: BigNumber;
+      uint256_1: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
     }>;
 
     input_tuple(
@@ -161,17 +123,9 @@ export class DataTypesInput extends Contract {
       1: BigNumber;
     }>;
 
-    input_uint256(
-      input1: BigNumberish
-    ): Promise<{
-      0: BigNumber;
-    }>;
+    input_uint256(input1: BigNumberish): Promise<BigNumber>;
 
-    input_uint8(
-      input1: BigNumberish
-    ): Promise<{
-      0: number;
-    }>;
+    input_uint8(input1: BigNumberish): Promise<number>;
   };
 
   input_address(input1: string): Promise<string>;

--- a/packages/target-ethers-v4-test/types/DataTypesInput.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesInput.d.ts
@@ -87,28 +87,55 @@ export class DataTypesInput extends Contract {
   interface: DataTypesInputInterface;
 
   functions: {
-    input_address(input1: string): Promise<string>;
+    input_address(
+      input1: string,
+      overrides?: TransactionOverrides
+    ): Promise<string>;
 
-    input_bool(input1: boolean): Promise<boolean>;
+    input_bool(
+      input1: boolean,
+      overrides?: TransactionOverrides
+    ): Promise<boolean>;
 
-    input_bytes(input1: Arrayish): Promise<string>;
+    input_bytes(
+      input1: Arrayish,
+      overrides?: TransactionOverrides
+    ): Promise<string>;
 
-    input_bytes1(input1: Arrayish): Promise<string>;
+    input_bytes1(
+      input1: Arrayish,
+      overrides?: TransactionOverrides
+    ): Promise<string>;
 
-    input_enum(input1: BigNumberish): Promise<number>;
+    input_enum(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<number>;
 
-    input_int256(input1: BigNumberish): Promise<BigNumber>;
+    input_int256(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_int8(input1: BigNumberish): Promise<number>;
+    input_int8(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<number>;
 
-    input_stat_array(input1: BigNumberish[]): Promise<number[]>;
+    input_stat_array(
+      input1: BigNumberish[],
+      overrides?: TransactionOverrides
+    ): Promise<number[]>;
 
-    input_string(input1: string): Promise<string>;
+    input_string(
+      input1: string,
+      overrides?: TransactionOverrides
+    ): Promise<string>;
 
-    input_struct(input1: {
-      uint256_0: BigNumberish;
-      uint256_1: BigNumberish;
-    }): Promise<{
+    input_struct(
+      input1: { uint256_0: BigNumberish; uint256_1: BigNumberish },
+      overrides?: TransactionOverrides
+    ): Promise<{
       uint256_0: BigNumber;
       uint256_1: BigNumber;
       0: BigNumber;
@@ -117,39 +144,73 @@ export class DataTypesInput extends Contract {
 
     input_tuple(
       input1: BigNumberish,
-      input2: BigNumberish
+      input2: BigNumberish,
+      overrides?: TransactionOverrides
     ): Promise<{
       0: BigNumber;
       1: BigNumber;
     }>;
 
-    input_uint256(input1: BigNumberish): Promise<BigNumber>;
+    input_uint256(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_uint8(input1: BigNumberish): Promise<number>;
+    input_uint8(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<number>;
   };
 
-  input_address(input1: string): Promise<string>;
+  input_address(
+    input1: string,
+    overrides?: TransactionOverrides
+  ): Promise<string>;
 
-  input_bool(input1: boolean): Promise<boolean>;
+  input_bool(
+    input1: boolean,
+    overrides?: TransactionOverrides
+  ): Promise<boolean>;
 
-  input_bytes(input1: Arrayish): Promise<string>;
+  input_bytes(
+    input1: Arrayish,
+    overrides?: TransactionOverrides
+  ): Promise<string>;
 
-  input_bytes1(input1: Arrayish): Promise<string>;
+  input_bytes1(
+    input1: Arrayish,
+    overrides?: TransactionOverrides
+  ): Promise<string>;
 
-  input_enum(input1: BigNumberish): Promise<number>;
+  input_enum(
+    input1: BigNumberish,
+    overrides?: TransactionOverrides
+  ): Promise<number>;
 
-  input_int256(input1: BigNumberish): Promise<BigNumber>;
+  input_int256(
+    input1: BigNumberish,
+    overrides?: TransactionOverrides
+  ): Promise<BigNumber>;
 
-  input_int8(input1: BigNumberish): Promise<number>;
+  input_int8(
+    input1: BigNumberish,
+    overrides?: TransactionOverrides
+  ): Promise<number>;
 
-  input_stat_array(input1: BigNumberish[]): Promise<number[]>;
+  input_stat_array(
+    input1: BigNumberish[],
+    overrides?: TransactionOverrides
+  ): Promise<number[]>;
 
-  input_string(input1: string): Promise<string>;
+  input_string(
+    input1: string,
+    overrides?: TransactionOverrides
+  ): Promise<string>;
 
-  input_struct(input1: {
-    uint256_0: BigNumberish;
-    uint256_1: BigNumberish;
-  }): Promise<{
+  input_struct(
+    input1: { uint256_0: BigNumberish; uint256_1: BigNumberish },
+    overrides?: TransactionOverrides
+  ): Promise<{
     uint256_0: BigNumber;
     uint256_1: BigNumber;
     0: BigNumber;
@@ -158,46 +219,90 @@ export class DataTypesInput extends Contract {
 
   input_tuple(
     input1: BigNumberish,
-    input2: BigNumberish
+    input2: BigNumberish,
+    overrides?: TransactionOverrides
   ): Promise<{
     0: BigNumber;
     1: BigNumber;
   }>;
 
-  input_uint256(input1: BigNumberish): Promise<BigNumber>;
+  input_uint256(
+    input1: BigNumberish,
+    overrides?: TransactionOverrides
+  ): Promise<BigNumber>;
 
-  input_uint8(input1: BigNumberish): Promise<number>;
+  input_uint8(
+    input1: BigNumberish,
+    overrides?: TransactionOverrides
+  ): Promise<number>;
 
   filters: {};
 
   estimate: {
-    input_address(input1: string): Promise<BigNumber>;
+    input_address(
+      input1: string,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_bool(input1: boolean): Promise<BigNumber>;
+    input_bool(
+      input1: boolean,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_bytes(input1: Arrayish): Promise<BigNumber>;
+    input_bytes(
+      input1: Arrayish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_bytes1(input1: Arrayish): Promise<BigNumber>;
+    input_bytes1(
+      input1: Arrayish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_enum(input1: BigNumberish): Promise<BigNumber>;
+    input_enum(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_int256(input1: BigNumberish): Promise<BigNumber>;
+    input_int256(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_int8(input1: BigNumberish): Promise<BigNumber>;
+    input_int8(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_stat_array(input1: BigNumberish[]): Promise<BigNumber>;
+    input_stat_array(
+      input1: BigNumberish[],
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_string(input1: string): Promise<BigNumber>;
+    input_string(
+      input1: string,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_struct(input1: {
-      uint256_0: BigNumberish;
-      uint256_1: BigNumberish;
-    }): Promise<BigNumber>;
+    input_struct(
+      input1: { uint256_0: BigNumberish; uint256_1: BigNumberish },
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_tuple(input1: BigNumberish, input2: BigNumberish): Promise<BigNumber>;
+    input_tuple(
+      input1: BigNumberish,
+      input2: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_uint256(input1: BigNumberish): Promise<BigNumber>;
+    input_uint256(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
-    input_uint8(input1: BigNumberish): Promise<BigNumber>;
+    input_uint8(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
   };
 }

--- a/packages/target-ethers-v4-test/types/DataTypesPure.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesPure.d.ts
@@ -61,19 +61,33 @@ export class DataTypesPure extends Contract {
   interface: DataTypesPureInterface;
 
   functions: {
-    pure_address(): Promise<string>;
+    pure_address(): Promise<{
+      0: string;
+    }>;
 
-    pure_bool(): Promise<boolean>;
+    pure_bool(): Promise<{
+      0: boolean;
+    }>;
 
-    pure_bytes(): Promise<string>;
+    pure_bytes(): Promise<{
+      0: string;
+    }>;
 
-    pure_bytes1(): Promise<string>;
+    pure_bytes1(): Promise<{
+      0: string;
+    }>;
 
-    pure_enum(): Promise<number>;
+    pure_enum(): Promise<{
+      0: number;
+    }>;
 
-    pure_int256(): Promise<BigNumber>;
+    pure_int256(): Promise<{
+      0: BigNumber;
+    }>;
 
-    pure_int8(): Promise<number>;
+    pure_int8(): Promise<{
+      0: number;
+    }>;
 
     pure_named(): Promise<{
       uint256_1: BigNumber;
@@ -82,15 +96,21 @@ export class DataTypesPure extends Contract {
       1: BigNumber;
     }>;
 
-    pure_stat_array(): Promise<number[]>;
+    pure_stat_array(): Promise<{
+      0: number[];
+    }>;
 
-    pure_string(): Promise<string>;
+    pure_string(): Promise<{
+      0: string;
+    }>;
 
     pure_struct(): Promise<{
-      uint256_0: BigNumber;
-      uint256_1: BigNumber;
-      0: BigNumber;
-      1: BigNumber;
+      0: {
+        uint256_0: BigNumber;
+        uint256_1: BigNumber;
+        0: BigNumber;
+        1: BigNumber;
+      };
     }>;
 
     pure_tuple(): Promise<{
@@ -98,9 +118,13 @@ export class DataTypesPure extends Contract {
       1: BigNumber;
     }>;
 
-    pure_uint256(): Promise<BigNumber>;
+    pure_uint256(): Promise<{
+      0: BigNumber;
+    }>;
 
-    pure_uint8(): Promise<number>;
+    pure_uint8(): Promise<{
+      0: number;
+    }>;
   };
 
   pure_address(): Promise<string>;

--- a/packages/target-ethers-v4-test/types/DataTypesPure.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesPure.d.ts
@@ -61,118 +61,130 @@ export class DataTypesPure extends Contract {
   interface: DataTypesPureInterface;
 
   functions: {
-    pure_address(): Promise<string>;
+    pure_address(overrides?: TransactionOverrides): Promise<string>;
 
-    pure_bool(): Promise<boolean>;
+    pure_bool(overrides?: TransactionOverrides): Promise<boolean>;
 
-    pure_bytes(): Promise<string>;
+    pure_bytes(overrides?: TransactionOverrides): Promise<string>;
 
-    pure_bytes1(): Promise<string>;
+    pure_bytes1(overrides?: TransactionOverrides): Promise<string>;
 
-    pure_enum(): Promise<number>;
+    pure_enum(overrides?: TransactionOverrides): Promise<number>;
 
-    pure_int256(): Promise<BigNumber>;
+    pure_int256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_int8(): Promise<number>;
+    pure_int8(overrides?: TransactionOverrides): Promise<number>;
 
-    pure_named(): Promise<{
+    pure_named(
+      overrides?: TransactionOverrides
+    ): Promise<{
       uint256_1: BigNumber;
       uint256_2: BigNumber;
       0: BigNumber;
       1: BigNumber;
     }>;
 
-    pure_stat_array(): Promise<number[]>;
+    pure_stat_array(overrides?: TransactionOverrides): Promise<number[]>;
 
-    pure_string(): Promise<string>;
+    pure_string(overrides?: TransactionOverrides): Promise<string>;
 
-    pure_struct(): Promise<{
+    pure_struct(
+      overrides?: TransactionOverrides
+    ): Promise<{
       uint256_0: BigNumber;
       uint256_1: BigNumber;
       0: BigNumber;
       1: BigNumber;
     }>;
 
-    pure_tuple(): Promise<{
+    pure_tuple(
+      overrides?: TransactionOverrides
+    ): Promise<{
       0: BigNumber;
       1: BigNumber;
     }>;
 
-    pure_uint256(): Promise<BigNumber>;
+    pure_uint256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_uint8(): Promise<number>;
+    pure_uint8(overrides?: TransactionOverrides): Promise<number>;
   };
 
-  pure_address(): Promise<string>;
+  pure_address(overrides?: TransactionOverrides): Promise<string>;
 
-  pure_bool(): Promise<boolean>;
+  pure_bool(overrides?: TransactionOverrides): Promise<boolean>;
 
-  pure_bytes(): Promise<string>;
+  pure_bytes(overrides?: TransactionOverrides): Promise<string>;
 
-  pure_bytes1(): Promise<string>;
+  pure_bytes1(overrides?: TransactionOverrides): Promise<string>;
 
-  pure_enum(): Promise<number>;
+  pure_enum(overrides?: TransactionOverrides): Promise<number>;
 
-  pure_int256(): Promise<BigNumber>;
+  pure_int256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-  pure_int8(): Promise<number>;
+  pure_int8(overrides?: TransactionOverrides): Promise<number>;
 
-  pure_named(): Promise<{
+  pure_named(
+    overrides?: TransactionOverrides
+  ): Promise<{
     uint256_1: BigNumber;
     uint256_2: BigNumber;
     0: BigNumber;
     1: BigNumber;
   }>;
 
-  pure_stat_array(): Promise<number[]>;
+  pure_stat_array(overrides?: TransactionOverrides): Promise<number[]>;
 
-  pure_string(): Promise<string>;
+  pure_string(overrides?: TransactionOverrides): Promise<string>;
 
-  pure_struct(): Promise<{
+  pure_struct(
+    overrides?: TransactionOverrides
+  ): Promise<{
     uint256_0: BigNumber;
     uint256_1: BigNumber;
     0: BigNumber;
     1: BigNumber;
   }>;
 
-  pure_tuple(): Promise<{
+  pure_tuple(
+    overrides?: TransactionOverrides
+  ): Promise<{
     0: BigNumber;
     1: BigNumber;
   }>;
 
-  pure_uint256(): Promise<BigNumber>;
+  pure_uint256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-  pure_uint8(): Promise<number>;
+  pure_uint8(overrides?: TransactionOverrides): Promise<number>;
 
   filters: {};
 
   estimate: {
-    pure_address(): Promise<BigNumber>;
+    pure_address(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_bool(): Promise<BigNumber>;
+    pure_bool(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_bytes(): Promise<BigNumber>;
+    pure_bytes(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_bytes1(): Promise<BigNumber>;
+    pure_bytes1(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_enum(): Promise<BigNumber>;
+    pure_enum(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_int256(): Promise<BigNumber>;
+    pure_int256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_int8(): Promise<BigNumber>;
+    pure_int8(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_named(): Promise<BigNumber>;
+    pure_named(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_stat_array(): Promise<BigNumber>;
+    pure_stat_array(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_string(): Promise<BigNumber>;
+    pure_string(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_struct(): Promise<BigNumber>;
+    pure_struct(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_tuple(): Promise<BigNumber>;
+    pure_tuple(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_uint256(): Promise<BigNumber>;
+    pure_uint256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    pure_uint8(): Promise<BigNumber>;
+    pure_uint8(overrides?: TransactionOverrides): Promise<BigNumber>;
   };
 }

--- a/packages/target-ethers-v4-test/types/DataTypesPure.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesPure.d.ts
@@ -61,33 +61,19 @@ export class DataTypesPure extends Contract {
   interface: DataTypesPureInterface;
 
   functions: {
-    pure_address(): Promise<{
-      0: string;
-    }>;
+    pure_address(): Promise<string>;
 
-    pure_bool(): Promise<{
-      0: boolean;
-    }>;
+    pure_bool(): Promise<boolean>;
 
-    pure_bytes(): Promise<{
-      0: string;
-    }>;
+    pure_bytes(): Promise<string>;
 
-    pure_bytes1(): Promise<{
-      0: string;
-    }>;
+    pure_bytes1(): Promise<string>;
 
-    pure_enum(): Promise<{
-      0: number;
-    }>;
+    pure_enum(): Promise<number>;
 
-    pure_int256(): Promise<{
-      0: BigNumber;
-    }>;
+    pure_int256(): Promise<BigNumber>;
 
-    pure_int8(): Promise<{
-      0: number;
-    }>;
+    pure_int8(): Promise<number>;
 
     pure_named(): Promise<{
       uint256_1: BigNumber;
@@ -96,21 +82,15 @@ export class DataTypesPure extends Contract {
       1: BigNumber;
     }>;
 
-    pure_stat_array(): Promise<{
-      0: number[];
-    }>;
+    pure_stat_array(): Promise<number[]>;
 
-    pure_string(): Promise<{
-      0: string;
-    }>;
+    pure_string(): Promise<string>;
 
     pure_struct(): Promise<{
-      0: {
-        uint256_0: BigNumber;
-        uint256_1: BigNumber;
-        0: BigNumber;
-        1: BigNumber;
-      };
+      uint256_0: BigNumber;
+      uint256_1: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
     }>;
 
     pure_tuple(): Promise<{
@@ -118,13 +98,9 @@ export class DataTypesPure extends Contract {
       1: BigNumber;
     }>;
 
-    pure_uint256(): Promise<{
-      0: BigNumber;
-    }>;
+    pure_uint256(): Promise<BigNumber>;
 
-    pure_uint8(): Promise<{
-      0: number;
-    }>;
+    pure_uint8(): Promise<number>;
   };
 
   pure_address(): Promise<string>;

--- a/packages/target-ethers-v4-test/types/DataTypesView.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesView.d.ts
@@ -61,118 +61,130 @@ export class DataTypesView extends Contract {
   interface: DataTypesViewInterface;
 
   functions: {
-    view_address(): Promise<string>;
+    view_address(overrides?: TransactionOverrides): Promise<string>;
 
-    view_bool(): Promise<boolean>;
+    view_bool(overrides?: TransactionOverrides): Promise<boolean>;
 
-    view_bytes(): Promise<string>;
+    view_bytes(overrides?: TransactionOverrides): Promise<string>;
 
-    view_bytes1(): Promise<string>;
+    view_bytes1(overrides?: TransactionOverrides): Promise<string>;
 
-    view_enum(): Promise<number>;
+    view_enum(overrides?: TransactionOverrides): Promise<number>;
 
-    view_int256(): Promise<BigNumber>;
+    view_int256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_int8(): Promise<number>;
+    view_int8(overrides?: TransactionOverrides): Promise<number>;
 
-    view_named(): Promise<{
+    view_named(
+      overrides?: TransactionOverrides
+    ): Promise<{
       uint256_1: BigNumber;
       uint256_2: BigNumber;
       0: BigNumber;
       1: BigNumber;
     }>;
 
-    view_stat_array(): Promise<number[]>;
+    view_stat_array(overrides?: TransactionOverrides): Promise<number[]>;
 
-    view_string(): Promise<string>;
+    view_string(overrides?: TransactionOverrides): Promise<string>;
 
-    view_struct(): Promise<{
+    view_struct(
+      overrides?: TransactionOverrides
+    ): Promise<{
       uint256_0: BigNumber;
       uint256_1: BigNumber;
       0: BigNumber;
       1: BigNumber;
     }>;
 
-    view_tuple(): Promise<{
+    view_tuple(
+      overrides?: TransactionOverrides
+    ): Promise<{
       0: BigNumber;
       1: BigNumber;
     }>;
 
-    view_uint256(): Promise<BigNumber>;
+    view_uint256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_uint8(): Promise<number>;
+    view_uint8(overrides?: TransactionOverrides): Promise<number>;
   };
 
-  view_address(): Promise<string>;
+  view_address(overrides?: TransactionOverrides): Promise<string>;
 
-  view_bool(): Promise<boolean>;
+  view_bool(overrides?: TransactionOverrides): Promise<boolean>;
 
-  view_bytes(): Promise<string>;
+  view_bytes(overrides?: TransactionOverrides): Promise<string>;
 
-  view_bytes1(): Promise<string>;
+  view_bytes1(overrides?: TransactionOverrides): Promise<string>;
 
-  view_enum(): Promise<number>;
+  view_enum(overrides?: TransactionOverrides): Promise<number>;
 
-  view_int256(): Promise<BigNumber>;
+  view_int256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-  view_int8(): Promise<number>;
+  view_int8(overrides?: TransactionOverrides): Promise<number>;
 
-  view_named(): Promise<{
+  view_named(
+    overrides?: TransactionOverrides
+  ): Promise<{
     uint256_1: BigNumber;
     uint256_2: BigNumber;
     0: BigNumber;
     1: BigNumber;
   }>;
 
-  view_stat_array(): Promise<number[]>;
+  view_stat_array(overrides?: TransactionOverrides): Promise<number[]>;
 
-  view_string(): Promise<string>;
+  view_string(overrides?: TransactionOverrides): Promise<string>;
 
-  view_struct(): Promise<{
+  view_struct(
+    overrides?: TransactionOverrides
+  ): Promise<{
     uint256_0: BigNumber;
     uint256_1: BigNumber;
     0: BigNumber;
     1: BigNumber;
   }>;
 
-  view_tuple(): Promise<{
+  view_tuple(
+    overrides?: TransactionOverrides
+  ): Promise<{
     0: BigNumber;
     1: BigNumber;
   }>;
 
-  view_uint256(): Promise<BigNumber>;
+  view_uint256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-  view_uint8(): Promise<number>;
+  view_uint8(overrides?: TransactionOverrides): Promise<number>;
 
   filters: {};
 
   estimate: {
-    view_address(): Promise<BigNumber>;
+    view_address(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_bool(): Promise<BigNumber>;
+    view_bool(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_bytes(): Promise<BigNumber>;
+    view_bytes(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_bytes1(): Promise<BigNumber>;
+    view_bytes1(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_enum(): Promise<BigNumber>;
+    view_enum(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_int256(): Promise<BigNumber>;
+    view_int256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_int8(): Promise<BigNumber>;
+    view_int8(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_named(): Promise<BigNumber>;
+    view_named(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_stat_array(): Promise<BigNumber>;
+    view_stat_array(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_string(): Promise<BigNumber>;
+    view_string(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_struct(): Promise<BigNumber>;
+    view_struct(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_tuple(): Promise<BigNumber>;
+    view_tuple(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_uint256(): Promise<BigNumber>;
+    view_uint256(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    view_uint8(): Promise<BigNumber>;
+    view_uint8(overrides?: TransactionOverrides): Promise<BigNumber>;
   };
 }

--- a/packages/target-ethers-v4-test/types/DataTypesView.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesView.d.ts
@@ -61,19 +61,33 @@ export class DataTypesView extends Contract {
   interface: DataTypesViewInterface;
 
   functions: {
-    view_address(): Promise<string>;
+    view_address(): Promise<{
+      0: string;
+    }>;
 
-    view_bool(): Promise<boolean>;
+    view_bool(): Promise<{
+      0: boolean;
+    }>;
 
-    view_bytes(): Promise<string>;
+    view_bytes(): Promise<{
+      0: string;
+    }>;
 
-    view_bytes1(): Promise<string>;
+    view_bytes1(): Promise<{
+      0: string;
+    }>;
 
-    view_enum(): Promise<number>;
+    view_enum(): Promise<{
+      0: number;
+    }>;
 
-    view_int256(): Promise<BigNumber>;
+    view_int256(): Promise<{
+      0: BigNumber;
+    }>;
 
-    view_int8(): Promise<number>;
+    view_int8(): Promise<{
+      0: number;
+    }>;
 
     view_named(): Promise<{
       uint256_1: BigNumber;
@@ -82,15 +96,21 @@ export class DataTypesView extends Contract {
       1: BigNumber;
     }>;
 
-    view_stat_array(): Promise<number[]>;
+    view_stat_array(): Promise<{
+      0: number[];
+    }>;
 
-    view_string(): Promise<string>;
+    view_string(): Promise<{
+      0: string;
+    }>;
 
     view_struct(): Promise<{
-      uint256_0: BigNumber;
-      uint256_1: BigNumber;
-      0: BigNumber;
-      1: BigNumber;
+      0: {
+        uint256_0: BigNumber;
+        uint256_1: BigNumber;
+        0: BigNumber;
+        1: BigNumber;
+      };
     }>;
 
     view_tuple(): Promise<{
@@ -98,9 +118,13 @@ export class DataTypesView extends Contract {
       1: BigNumber;
     }>;
 
-    view_uint256(): Promise<BigNumber>;
+    view_uint256(): Promise<{
+      0: BigNumber;
+    }>;
 
-    view_uint8(): Promise<number>;
+    view_uint8(): Promise<{
+      0: number;
+    }>;
   };
 
   view_address(): Promise<string>;

--- a/packages/target-ethers-v4-test/types/DataTypesView.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesView.d.ts
@@ -61,33 +61,19 @@ export class DataTypesView extends Contract {
   interface: DataTypesViewInterface;
 
   functions: {
-    view_address(): Promise<{
-      0: string;
-    }>;
+    view_address(): Promise<string>;
 
-    view_bool(): Promise<{
-      0: boolean;
-    }>;
+    view_bool(): Promise<boolean>;
 
-    view_bytes(): Promise<{
-      0: string;
-    }>;
+    view_bytes(): Promise<string>;
 
-    view_bytes1(): Promise<{
-      0: string;
-    }>;
+    view_bytes1(): Promise<string>;
 
-    view_enum(): Promise<{
-      0: number;
-    }>;
+    view_enum(): Promise<number>;
 
-    view_int256(): Promise<{
-      0: BigNumber;
-    }>;
+    view_int256(): Promise<BigNumber>;
 
-    view_int8(): Promise<{
-      0: number;
-    }>;
+    view_int8(): Promise<number>;
 
     view_named(): Promise<{
       uint256_1: BigNumber;
@@ -96,21 +82,15 @@ export class DataTypesView extends Contract {
       1: BigNumber;
     }>;
 
-    view_stat_array(): Promise<{
-      0: number[];
-    }>;
+    view_stat_array(): Promise<number[]>;
 
-    view_string(): Promise<{
-      0: string;
-    }>;
+    view_string(): Promise<string>;
 
     view_struct(): Promise<{
-      0: {
-        uint256_0: BigNumber;
-        uint256_1: BigNumber;
-        0: BigNumber;
-        1: BigNumber;
-      };
+      uint256_0: BigNumber;
+      uint256_1: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
     }>;
 
     view_tuple(): Promise<{
@@ -118,13 +98,9 @@ export class DataTypesView extends Contract {
       1: BigNumber;
     }>;
 
-    view_uint256(): Promise<{
-      0: BigNumber;
-    }>;
+    view_uint256(): Promise<BigNumber>;
 
-    view_uint8(): Promise<{
-      0: number;
-    }>;
+    view_uint8(): Promise<number>;
   };
 
   view_address(): Promise<string>;

--- a/packages/target-ethers-v4-test/types/Events.d.ts
+++ b/packages/target-ethers-v4-test/types/Events.d.ts
@@ -92,14 +92,16 @@ export class Events extends Contract {
   };
 
   estimate: {
-    emit_anon1(): Promise<BigNumber>;
+    emit_anon1(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    emit_event1(): Promise<BigNumber>;
+    emit_event1(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    emit_event2(): Promise<BigNumber>;
+    emit_event2(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    emit_event3(): Promise<BigNumber>;
+    emit_event3(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    emit_event3_overloaded(): Promise<BigNumber>;
+    emit_event3_overloaded(
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
   };
 }

--- a/packages/target-ethers-v4-test/types/NameMangling.d.ts
+++ b/packages/target-ethers-v4-test/types/NameMangling.d.ts
@@ -35,9 +35,7 @@ export class NameMangling extends Contract {
   interface: NameManglingInterface;
 
   functions: {
-    works(): Promise<{
-      0: boolean;
-    }>;
+    works(): Promise<boolean>;
   };
 
   works(): Promise<boolean>;

--- a/packages/target-ethers-v4-test/types/NameMangling.d.ts
+++ b/packages/target-ethers-v4-test/types/NameMangling.d.ts
@@ -35,7 +35,9 @@ export class NameMangling extends Contract {
   interface: NameManglingInterface;
 
   functions: {
-    works(): Promise<boolean>;
+    works(): Promise<{
+      0: boolean;
+    }>;
   };
 
   works(): Promise<boolean>;

--- a/packages/target-ethers-v4-test/types/NameMangling.d.ts
+++ b/packages/target-ethers-v4-test/types/NameMangling.d.ts
@@ -35,14 +35,14 @@ export class NameMangling extends Contract {
   interface: NameManglingInterface;
 
   functions: {
-    works(): Promise<boolean>;
+    works(overrides?: TransactionOverrides): Promise<boolean>;
   };
 
-  works(): Promise<boolean>;
+  works(overrides?: TransactionOverrides): Promise<boolean>;
 
   filters: {};
 
   estimate: {
-    works(): Promise<BigNumber>;
+    works(overrides?: TransactionOverrides): Promise<BigNumber>;
   };
 }

--- a/packages/target-ethers-v4-test/types/Overloads.d.ts
+++ b/packages/target-ethers-v4-test/types/Overloads.d.ts
@@ -34,18 +34,12 @@ export class Overloads extends Contract {
   interface: OverloadsInterface;
 
   functions: {
-    "overload1(int256)"(
-      input1: BigNumberish
-    ): Promise<{
-      0: BigNumber;
-    }>;
+    "overload1(int256)"(input1: BigNumberish): Promise<BigNumber>;
 
     "overload1(uint256,uint256)"(
       input1: BigNumberish,
       input2: BigNumberish
-    ): Promise<{
-      0: BigNumber;
-    }>;
+    ): Promise<BigNumber>;
   };
 
   "overload1(int256)"(input1: BigNumberish): Promise<BigNumber>;

--- a/packages/target-ethers-v4-test/types/Overloads.d.ts
+++ b/packages/target-ethers-v4-test/types/Overloads.d.ts
@@ -34,12 +34,18 @@ export class Overloads extends Contract {
   interface: OverloadsInterface;
 
   functions: {
-    "overload1(int256)"(input1: BigNumberish): Promise<BigNumber>;
+    "overload1(int256)"(
+      input1: BigNumberish
+    ): Promise<{
+      0: BigNumber;
+    }>;
 
     "overload1(uint256,uint256)"(
       input1: BigNumberish,
       input2: BigNumberish
-    ): Promise<BigNumber>;
+    ): Promise<{
+      0: BigNumber;
+    }>;
   };
 
   "overload1(int256)"(input1: BigNumberish): Promise<BigNumber>;
@@ -52,6 +58,11 @@ export class Overloads extends Contract {
   filters: {};
 
   estimate: {
-    overload1(input1: BigNumberish): Promise<BigNumber>;
+    "overload1(int256)"(input1: BigNumberish): Promise<BigNumber>;
+
+    "overload1(uint256,uint256)"(
+      input1: BigNumberish,
+      input2: BigNumberish
+    ): Promise<BigNumber>;
   };
 }

--- a/packages/target-ethers-v4-test/types/Overloads.d.ts
+++ b/packages/target-ethers-v4-test/types/Overloads.d.ts
@@ -34,29 +34,41 @@ export class Overloads extends Contract {
   interface: OverloadsInterface;
 
   functions: {
-    "overload1(int256)"(input1: BigNumberish): Promise<BigNumber>;
+    "overload1(int256)"(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
     "overload1(uint256,uint256)"(
       input1: BigNumberish,
-      input2: BigNumberish
+      input2: BigNumberish,
+      overrides?: TransactionOverrides
     ): Promise<BigNumber>;
   };
 
-  "overload1(int256)"(input1: BigNumberish): Promise<BigNumber>;
+  "overload1(int256)"(
+    input1: BigNumberish,
+    overrides?: TransactionOverrides
+  ): Promise<BigNumber>;
 
   "overload1(uint256,uint256)"(
     input1: BigNumberish,
-    input2: BigNumberish
+    input2: BigNumberish,
+    overrides?: TransactionOverrides
   ): Promise<BigNumber>;
 
   filters: {};
 
   estimate: {
-    "overload1(int256)"(input1: BigNumberish): Promise<BigNumber>;
+    "overload1(int256)"(
+      input1: BigNumberish,
+      overrides?: TransactionOverrides
+    ): Promise<BigNumber>;
 
     "overload1(uint256,uint256)"(
       input1: BigNumberish,
-      input2: BigNumberish
+      input2: BigNumberish,
+      overrides?: TransactionOverrides
     ): Promise<BigNumber>;
   };
 }

--- a/packages/target-ethers-v4-test/types/Payable.d.ts
+++ b/packages/target-ethers-v4-test/types/Payable.d.ts
@@ -52,8 +52,8 @@ export class Payable extends Contract {
   filters: {};
 
   estimate: {
-    non_payable_func(): Promise<BigNumber>;
+    non_payable_func(overrides?: TransactionOverrides): Promise<BigNumber>;
 
-    payable_func(): Promise<BigNumber>;
+    payable_func(overrides?: TransactionOverrides): Promise<BigNumber>;
   };
 }

--- a/packages/target-ethers-v4-test/types/index.d.ts
+++ b/packages/target-ethers-v4-test/types/index.d.ts
@@ -6,11 +6,12 @@ import {
   FunctionDescription
 } from "ethers/utils";
 
-export class TransactionOverrides {
-  nonce?: BigNumberish | Promise<BigNumberish>;
+export interface TransactionOverrides {
   gasLimit?: BigNumberish | Promise<BigNumberish>;
   gasPrice?: BigNumberish | Promise<BigNumberish>;
+  nonce?: BigNumberish | Promise<BigNumberish>;
   value?: BigNumberish | Promise<BigNumberish>;
+  from?: string | Promise<string>;
   chainId?: number | Promise<number>;
 }
 

--- a/packages/target-ethers-v4/src/codegen/functions.ts
+++ b/packages/target-ethers-v4/src/codegen/functions.ts
@@ -1,4 +1,4 @@
-import { FunctionDeclaration, isConstant, isConstantFn, FunctionDocumentation, getSignatureForFn } from 'typechain'
+import { FunctionDeclaration, FunctionDocumentation, getSignatureForFn } from 'typechain'
 import { generateInputTypes, generateOutputTypes } from './types'
 
 interface GenerateFunctionOptions {
@@ -20,9 +20,7 @@ export function codegenForOverloadedFunctions(options: GenerateFunctionOptions, 
 function generateFunction(options: GenerateFunctionOptions, fn: FunctionDeclaration, overloadedName?: string): string {
   return `
   ${generateFunctionDocumentation(fn.documentation)}
-  ${overloadedName ?? fn.name}(${generateInputTypes(fn.inputs)}${
-    !isConstant(fn) && !isConstantFn(fn) ? 'overrides?: TransactionOverrides' : ''
-  }): ${
+  ${overloadedName ?? fn.name}(${generateInputTypes(fn.inputs)} overrides?: TransactionOverrides): ${
     options.overrideOutput
       ? options.overrideOutput
       : `Promise<${

--- a/packages/target-ethers-v4/src/codegen/functions.ts
+++ b/packages/target-ethers-v4/src/codegen/functions.ts
@@ -2,7 +2,6 @@ import { FunctionDeclaration, isConstant, isConstantFn, FunctionDocumentation, g
 import { generateInputTypes, generateOutputTypes } from './types'
 
 interface GenerateFunctionOptions {
-  returnResultObject?: boolean
   overrideOutput?: string
 }
 
@@ -28,7 +27,7 @@ function generateFunction(options: GenerateFunctionOptions, fn: FunctionDeclarat
       ? options.overrideOutput
       : `Promise<${
           fn.stateMutability === 'pure' || fn.stateMutability === 'view'
-            ? generateOutputTypes(!!options.returnResultObject, fn.outputs)
+            ? generateOutputTypes(fn.outputs)
             : 'ContractTransaction'
         }>`
   };

--- a/packages/target-ethers-v4/src/codegen/index.ts
+++ b/packages/target-ethers-v4/src/codegen/index.ts
@@ -47,10 +47,12 @@ export function codegenContractTypings(contract: Contract) {
     interface: ${contract.name}Interface;
 
     functions: {
-      ${values(contract.functions).map(codegenFunctions).join('\n')}
+      ${values(contract.functions)
+        .map(codegenFunctions.bind(null, { returnResultObject: true }))
+        .join('\n')}
     };
 
-    ${values(contract.functions).map(codegenFunctions).join('\n')}
+    ${values(contract.functions).map(codegenFunctions.bind(null, {})).join('\n')}
 
     filters: {
       ${values(contract.events)
@@ -61,8 +63,7 @@ export function codegenContractTypings(contract: Contract) {
 
     estimate: {
       ${values(contract.functions)
-        .map((v) => v[0])
-        .map(generateEstimateFunction)
+        .map(codegenFunctions.bind(null, { overrideOutput: 'Promise<BigNumber>' }))
         .join('\n')}
     };
   }`
@@ -186,12 +187,6 @@ function generateLibraryAddressesInterface(contract: Contract, bytecode: Bytecod
   export interface ${contract.name}LibraryAddresses {
     ${linkLibrariesKeys.join('\n')}
   };`
-}
-
-function generateEstimateFunction(fn: FunctionDeclaration): string {
-  return `
-  ${fn.name}(${generateInputTypes(fn.inputs)}): Promise<BigNumber>;
-`
 }
 
 function generateInterfaceFunctionDescription(fn: FunctionDeclaration): string {

--- a/packages/target-ethers-v4/src/codegen/index.ts
+++ b/packages/target-ethers-v4/src/codegen/index.ts
@@ -47,9 +47,7 @@ export function codegenContractTypings(contract: Contract) {
     interface: ${contract.name}Interface;
 
     functions: {
-      ${values(contract.functions)
-        .map(codegenFunctions.bind(null, { returnResultObject: true }))
-        .join('\n')}
+      ${values(contract.functions).map(codegenFunctions.bind(null, {})).join('\n')}
     };
 
     ${values(contract.functions).map(codegenFunctions.bind(null, {})).join('\n')}

--- a/packages/target-ethers-v4/src/codegen/types.ts
+++ b/packages/target-ethers-v4/src/codegen/types.ts
@@ -9,8 +9,8 @@ export function generateInputTypes(input: Array<AbiParameter>): string {
   )
 }
 
-export function generateOutputTypes(returnResultObject: boolean, outputs: Array<AbiOutputParameter>): string {
-  if (!returnResultObject && outputs.length === 1) {
+export function generateOutputTypes(outputs: Array<AbiOutputParameter>): string {
+  if (outputs.length === 1) {
     return generateOutputType(outputs[0].type)
   } else {
     return `{

--- a/packages/target-ethers-v4/src/codegen/types.ts
+++ b/packages/target-ethers-v4/src/codegen/types.ts
@@ -9,8 +9,8 @@ export function generateInputTypes(input: Array<AbiParameter>): string {
   )
 }
 
-export function generateOutputTypes(outputs: Array<AbiOutputParameter>): string {
-  if (outputs.length === 1) {
+export function generateOutputTypes(returnResultObject: boolean, outputs: Array<AbiOutputParameter>): string {
+  if (!returnResultObject && outputs.length === 1) {
     return generateOutputType(outputs[0].type)
   } else {
     return `{

--- a/packages/target-ethers-v4/static/index.d.ts
+++ b/packages/target-ethers-v4/static/index.d.ts
@@ -1,10 +1,11 @@
 import { BigNumberish, EventDescription, FunctionDescription } from 'ethers/utils'
 
-export class TransactionOverrides {
-  nonce?: BigNumberish | Promise<BigNumberish>
+export interface TransactionOverrides {
   gasLimit?: BigNumberish | Promise<BigNumberish>
   gasPrice?: BigNumberish | Promise<BigNumberish>
+  nonce?: BigNumberish | Promise<BigNumberish>
   value?: BigNumberish | Promise<BigNumberish>
+  from?: string | Promise<string>
   chainId?: number | Promise<number>
 }
 


### PR DESCRIPTION
Similar to https://github.com/ethereum-ts/TypeChain/pull/254 - this fixes the situation to provide override arguments as specified.  

There are a few specifics that are considered here:

- According to [the documentation](https://docs.ethers.io/v4/api-contract.html#overrides) for ethers v4 (and my own experience where i needed these overrides), **every** method has overrides available to it.  Their example only shows a few properties but when looking at the v5 types they are defined extending the transaciton overrides while adding a `from` key (and `blockTag` which im not sure, i didnt add that). 

- I did not add the differentiation that the `target-ethers-v5` has where it checks if the fn is a constant function - this is due to the fact that it seemed to be doing some extra changes to handle that properly and I didn't want this to get too big of a change.

- I added some tests to call both the contract and the `contract.functions` method - although not testing the overrides being used as I wasn't sure the best way to implement that with y;alls setup.  I just needed this to be working right for our project  :-)

- When using overloads there is a slight bug that should be addressed (probably in another PR).  When you use overloads, [the first function defined should be defined as the name of the fn](https://github.com/ethers-io/ethers.js/issues/407#issuecomment-458329708), then all overloads should have the function names.  

---

The 3 PR's combined, which we are using to generate working types for our contracts is https://github.com/bradennapier/TypeChain/tree/combined-prs