### PR TITLE
fix: overloads to work according to spec

### DIFF
--- a/packages/target-ethers-v4-test/test/DataTypesInput.test.ts
+++ b/packages/target-ethers-v4-test/test/DataTypesInput.test.ts
@@ -35,6 +35,11 @@ describe('DataTypesInput', () => {
       '0x70b144972C5Ef6CB941A5379240B74239c418CD4',
     )
 
+    typedAssert(
+      await contract['input_address(address)']('0x70b144972C5Ef6CB941A5379240B74239c418CD4'),
+      '0x70b144972C5Ef6CB941A5379240B74239c418CD4',
+    )
+
     typedAssert(await contract.input_bytes1('0xaa'), '0xaa')
     typedAssert(await contract.input_bytes1([0]), '0x00')
 

--- a/packages/target-ethers-v4-test/test/Overload.test.ts
+++ b/packages/target-ethers-v4-test/test/Overload.test.ts
@@ -16,12 +16,20 @@ describe('Overloads', () => {
   afterEach(() => ganache.close())
 
   it('works with 1st overload', async () => {
-    const result = await contract.functions['overload1(int256)'](1)
-    typedAssert(result, new BigNumber(1))
+    const results = await Promise.all([
+      contract['overload1(int256)'](1),
+      contract.functions['overload1(int256)'](1),
+      contract.functions.overload1(1),
+      contract.overload1(1),
+    ])
+    results.forEach((result) => typedAssert(result, new BigNumber(1)))
   })
 
   it('works with 2n overload', async () => {
-    const result = await contract.functions['overload1(uint256,uint256)'](1, 2)
-    typedAssert(result, new BigNumber(3))
+    const results = await Promise.all([
+      contract.functions['overload1(uint256,uint256)'](1, 2),
+      contract['overload1(uint256,uint256)'](1, 2),
+    ])
+    results.forEach((result) => typedAssert(result, new BigNumber(3)))
   })
 })

--- a/packages/target-ethers-v4-test/types/DataTypesInput.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesInput.d.ts
@@ -89,23 +89,51 @@ export class DataTypesInput extends Contract {
   functions: {
     input_address(input1: string): Promise<string>;
 
+    "input_address(address)"(input1: string): Promise<string>;
+
     input_bool(input1: boolean): Promise<boolean>;
+
+    "input_bool(bool)"(input1: boolean): Promise<boolean>;
 
     input_bytes(input1: Arrayish): Promise<string>;
 
+    "input_bytes(bytes)"(input1: Arrayish): Promise<string>;
+
     input_bytes1(input1: Arrayish): Promise<string>;
+
+    "input_bytes1(bytes1)"(input1: Arrayish): Promise<string>;
 
     input_enum(input1: BigNumberish): Promise<number>;
 
+    "input_enum(uint8)"(input1: BigNumberish): Promise<number>;
+
     input_int256(input1: BigNumberish): Promise<BigNumber>;
+
+    "input_int256(int256)"(input1: BigNumberish): Promise<BigNumber>;
 
     input_int8(input1: BigNumberish): Promise<number>;
 
+    "input_int8(int8)"(input1: BigNumberish): Promise<number>;
+
     input_stat_array(input1: BigNumberish[]): Promise<number[]>;
+
+    "input_stat_array(uint8[3])"(input1: BigNumberish[]): Promise<number[]>;
 
     input_string(input1: string): Promise<string>;
 
+    "input_string(string)"(input1: string): Promise<string>;
+
     input_struct(input1: {
+      uint256_0: BigNumberish;
+      uint256_1: BigNumberish;
+    }): Promise<{
+      uint256_0: BigNumber;
+      uint256_1: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
+    "input_struct(tuple)"(input1: {
       uint256_0: BigNumberish;
       uint256_1: BigNumberish;
     }): Promise<{
@@ -123,30 +151,70 @@ export class DataTypesInput extends Contract {
       1: BigNumber;
     }>;
 
+    "input_tuple(uint256,uint256)"(
+      input1: BigNumberish,
+      input2: BigNumberish
+    ): Promise<{
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     input_uint256(input1: BigNumberish): Promise<BigNumber>;
 
+    "input_uint256(uint256)"(input1: BigNumberish): Promise<BigNumber>;
+
     input_uint8(input1: BigNumberish): Promise<number>;
+
+    "input_uint8(uint8)"(input1: BigNumberish): Promise<number>;
   };
 
   input_address(input1: string): Promise<string>;
 
+  "input_address(address)"(input1: string): Promise<string>;
+
   input_bool(input1: boolean): Promise<boolean>;
+
+  "input_bool(bool)"(input1: boolean): Promise<boolean>;
 
   input_bytes(input1: Arrayish): Promise<string>;
 
+  "input_bytes(bytes)"(input1: Arrayish): Promise<string>;
+
   input_bytes1(input1: Arrayish): Promise<string>;
+
+  "input_bytes1(bytes1)"(input1: Arrayish): Promise<string>;
 
   input_enum(input1: BigNumberish): Promise<number>;
 
+  "input_enum(uint8)"(input1: BigNumberish): Promise<number>;
+
   input_int256(input1: BigNumberish): Promise<BigNumber>;
+
+  "input_int256(int256)"(input1: BigNumberish): Promise<BigNumber>;
 
   input_int8(input1: BigNumberish): Promise<number>;
 
+  "input_int8(int8)"(input1: BigNumberish): Promise<number>;
+
   input_stat_array(input1: BigNumberish[]): Promise<number[]>;
+
+  "input_stat_array(uint8[3])"(input1: BigNumberish[]): Promise<number[]>;
 
   input_string(input1: string): Promise<string>;
 
+  "input_string(string)"(input1: string): Promise<string>;
+
   input_struct(input1: {
+    uint256_0: BigNumberish;
+    uint256_1: BigNumberish;
+  }): Promise<{
+    uint256_0: BigNumber;
+    uint256_1: BigNumber;
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
+  "input_struct(tuple)"(input1: {
     uint256_0: BigNumberish;
     uint256_1: BigNumberish;
   }): Promise<{
@@ -164,9 +232,21 @@ export class DataTypesInput extends Contract {
     1: BigNumber;
   }>;
 
+  "input_tuple(uint256,uint256)"(
+    input1: BigNumberish,
+    input2: BigNumberish
+  ): Promise<{
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
   input_uint256(input1: BigNumberish): Promise<BigNumber>;
 
+  "input_uint256(uint256)"(input1: BigNumberish): Promise<BigNumber>;
+
   input_uint8(input1: BigNumberish): Promise<number>;
+
+  "input_uint8(uint8)"(input1: BigNumberish): Promise<number>;
 
   filters: {};
 

--- a/packages/target-ethers-v4-test/types/DataTypesPure.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesPure.d.ts
@@ -63,17 +63,31 @@ export class DataTypesPure extends Contract {
   functions: {
     pure_address(): Promise<string>;
 
+    "pure_address()"(): Promise<string>;
+
     pure_bool(): Promise<boolean>;
+
+    "pure_bool()"(): Promise<boolean>;
 
     pure_bytes(): Promise<string>;
 
+    "pure_bytes()"(): Promise<string>;
+
     pure_bytes1(): Promise<string>;
+
+    "pure_bytes1()"(): Promise<string>;
 
     pure_enum(): Promise<number>;
 
+    "pure_enum()"(): Promise<number>;
+
     pure_int256(): Promise<BigNumber>;
 
+    "pure_int256()"(): Promise<BigNumber>;
+
     pure_int8(): Promise<number>;
+
+    "pure_int8()"(): Promise<number>;
 
     pure_named(): Promise<{
       uint256_1: BigNumber;
@@ -82,11 +96,29 @@ export class DataTypesPure extends Contract {
       1: BigNumber;
     }>;
 
+    "pure_named()"(): Promise<{
+      uint256_1: BigNumber;
+      uint256_2: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     pure_stat_array(): Promise<number[]>;
+
+    "pure_stat_array()"(): Promise<number[]>;
 
     pure_string(): Promise<string>;
 
+    "pure_string()"(): Promise<string>;
+
     pure_struct(): Promise<{
+      uint256_0: BigNumber;
+      uint256_1: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
+    "pure_struct()"(): Promise<{
       uint256_0: BigNumber;
       uint256_1: BigNumber;
       0: BigNumber;
@@ -98,24 +130,47 @@ export class DataTypesPure extends Contract {
       1: BigNumber;
     }>;
 
+    "pure_tuple()"(): Promise<{
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     pure_uint256(): Promise<BigNumber>;
 
+    "pure_uint256()"(): Promise<BigNumber>;
+
     pure_uint8(): Promise<number>;
+
+    "pure_uint8()"(): Promise<number>;
   };
 
   pure_address(): Promise<string>;
 
+  "pure_address()"(): Promise<string>;
+
   pure_bool(): Promise<boolean>;
+
+  "pure_bool()"(): Promise<boolean>;
 
   pure_bytes(): Promise<string>;
 
+  "pure_bytes()"(): Promise<string>;
+
   pure_bytes1(): Promise<string>;
+
+  "pure_bytes1()"(): Promise<string>;
 
   pure_enum(): Promise<number>;
 
+  "pure_enum()"(): Promise<number>;
+
   pure_int256(): Promise<BigNumber>;
 
+  "pure_int256()"(): Promise<BigNumber>;
+
   pure_int8(): Promise<number>;
+
+  "pure_int8()"(): Promise<number>;
 
   pure_named(): Promise<{
     uint256_1: BigNumber;
@@ -124,11 +179,29 @@ export class DataTypesPure extends Contract {
     1: BigNumber;
   }>;
 
+  "pure_named()"(): Promise<{
+    uint256_1: BigNumber;
+    uint256_2: BigNumber;
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
   pure_stat_array(): Promise<number[]>;
+
+  "pure_stat_array()"(): Promise<number[]>;
 
   pure_string(): Promise<string>;
 
+  "pure_string()"(): Promise<string>;
+
   pure_struct(): Promise<{
+    uint256_0: BigNumber;
+    uint256_1: BigNumber;
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
+  "pure_struct()"(): Promise<{
     uint256_0: BigNumber;
     uint256_1: BigNumber;
     0: BigNumber;
@@ -140,9 +213,18 @@ export class DataTypesPure extends Contract {
     1: BigNumber;
   }>;
 
+  "pure_tuple()"(): Promise<{
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
   pure_uint256(): Promise<BigNumber>;
 
+  "pure_uint256()"(): Promise<BigNumber>;
+
   pure_uint8(): Promise<number>;
+
+  "pure_uint8()"(): Promise<number>;
 
   filters: {};
 

--- a/packages/target-ethers-v4-test/types/DataTypesView.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesView.d.ts
@@ -63,17 +63,31 @@ export class DataTypesView extends Contract {
   functions: {
     view_address(): Promise<string>;
 
+    "view_address()"(): Promise<string>;
+
     view_bool(): Promise<boolean>;
+
+    "view_bool()"(): Promise<boolean>;
 
     view_bytes(): Promise<string>;
 
+    "view_bytes()"(): Promise<string>;
+
     view_bytes1(): Promise<string>;
+
+    "view_bytes1()"(): Promise<string>;
 
     view_enum(): Promise<number>;
 
+    "view_enum()"(): Promise<number>;
+
     view_int256(): Promise<BigNumber>;
 
+    "view_int256()"(): Promise<BigNumber>;
+
     view_int8(): Promise<number>;
+
+    "view_int8()"(): Promise<number>;
 
     view_named(): Promise<{
       uint256_1: BigNumber;
@@ -82,11 +96,29 @@ export class DataTypesView extends Contract {
       1: BigNumber;
     }>;
 
+    "view_named()"(): Promise<{
+      uint256_1: BigNumber;
+      uint256_2: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     view_stat_array(): Promise<number[]>;
+
+    "view_stat_array()"(): Promise<number[]>;
 
     view_string(): Promise<string>;
 
+    "view_string()"(): Promise<string>;
+
     view_struct(): Promise<{
+      uint256_0: BigNumber;
+      uint256_1: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
+    "view_struct()"(): Promise<{
       uint256_0: BigNumber;
       uint256_1: BigNumber;
       0: BigNumber;
@@ -98,24 +130,47 @@ export class DataTypesView extends Contract {
       1: BigNumber;
     }>;
 
+    "view_tuple()"(): Promise<{
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     view_uint256(): Promise<BigNumber>;
 
+    "view_uint256()"(): Promise<BigNumber>;
+
     view_uint8(): Promise<number>;
+
+    "view_uint8()"(): Promise<number>;
   };
 
   view_address(): Promise<string>;
 
+  "view_address()"(): Promise<string>;
+
   view_bool(): Promise<boolean>;
+
+  "view_bool()"(): Promise<boolean>;
 
   view_bytes(): Promise<string>;
 
+  "view_bytes()"(): Promise<string>;
+
   view_bytes1(): Promise<string>;
+
+  "view_bytes1()"(): Promise<string>;
 
   view_enum(): Promise<number>;
 
+  "view_enum()"(): Promise<number>;
+
   view_int256(): Promise<BigNumber>;
 
+  "view_int256()"(): Promise<BigNumber>;
+
   view_int8(): Promise<number>;
+
+  "view_int8()"(): Promise<number>;
 
   view_named(): Promise<{
     uint256_1: BigNumber;
@@ -124,11 +179,29 @@ export class DataTypesView extends Contract {
     1: BigNumber;
   }>;
 
+  "view_named()"(): Promise<{
+    uint256_1: BigNumber;
+    uint256_2: BigNumber;
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
   view_stat_array(): Promise<number[]>;
+
+  "view_stat_array()"(): Promise<number[]>;
 
   view_string(): Promise<string>;
 
+  "view_string()"(): Promise<string>;
+
   view_struct(): Promise<{
+    uint256_0: BigNumber;
+    uint256_1: BigNumber;
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
+  "view_struct()"(): Promise<{
     uint256_0: BigNumber;
     uint256_1: BigNumber;
     0: BigNumber;
@@ -140,9 +213,18 @@ export class DataTypesView extends Contract {
     1: BigNumber;
   }>;
 
+  "view_tuple()"(): Promise<{
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
   view_uint256(): Promise<BigNumber>;
 
+  "view_uint256()"(): Promise<BigNumber>;
+
   view_uint8(): Promise<number>;
+
+  "view_uint8()"(): Promise<number>;
 
   filters: {};
 

--- a/packages/target-ethers-v4-test/types/Events.d.ts
+++ b/packages/target-ethers-v4-test/types/Events.d.ts
@@ -58,26 +58,66 @@ export class Events extends Contract {
   functions: {
     emit_anon1(overrides?: TransactionOverrides): Promise<ContractTransaction>;
 
+    "emit_anon1()"(
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
+
     emit_event1(overrides?: TransactionOverrides): Promise<ContractTransaction>;
+
+    "emit_event1()"(
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
 
     emit_event2(overrides?: TransactionOverrides): Promise<ContractTransaction>;
 
+    "emit_event2()"(
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
+
     emit_event3(overrides?: TransactionOverrides): Promise<ContractTransaction>;
 
+    "emit_event3()"(
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
+
     emit_event3_overloaded(
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
+
+    "emit_event3_overloaded()"(
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
   };
 
   emit_anon1(overrides?: TransactionOverrides): Promise<ContractTransaction>;
 
+  "emit_anon1()"(
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
+
   emit_event1(overrides?: TransactionOverrides): Promise<ContractTransaction>;
+
+  "emit_event1()"(
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
 
   emit_event2(overrides?: TransactionOverrides): Promise<ContractTransaction>;
 
+  "emit_event2()"(
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
+
   emit_event3(overrides?: TransactionOverrides): Promise<ContractTransaction>;
 
+  "emit_event3()"(
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
+
   emit_event3_overloaded(
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
+
+  "emit_event3_overloaded()"(
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 

--- a/packages/target-ethers-v4-test/types/NameMangling.d.ts
+++ b/packages/target-ethers-v4-test/types/NameMangling.d.ts
@@ -36,9 +36,13 @@ export class NameMangling extends Contract {
 
   functions: {
     works(): Promise<boolean>;
+
+    "works()"(): Promise<boolean>;
   };
 
   works(): Promise<boolean>;
+
+  "works()"(): Promise<boolean>;
 
   filters: {};
 

--- a/packages/target-ethers-v4-test/types/Overloads.d.ts
+++ b/packages/target-ethers-v4-test/types/Overloads.d.ts
@@ -34,6 +34,8 @@ export class Overloads extends Contract {
   interface: OverloadsInterface;
 
   functions: {
+    overload1(input1: BigNumberish): Promise<BigNumber>;
+
     "overload1(int256)"(input1: BigNumberish): Promise<BigNumber>;
 
     "overload1(uint256,uint256)"(
@@ -41,6 +43,8 @@ export class Overloads extends Contract {
       input2: BigNumberish
     ): Promise<BigNumber>;
   };
+
+  overload1(input1: BigNumberish): Promise<BigNumber>;
 
   "overload1(int256)"(input1: BigNumberish): Promise<BigNumber>;
 

--- a/packages/target-ethers-v4-test/types/Payable.d.ts
+++ b/packages/target-ethers-v4-test/types/Payable.d.ts
@@ -38,7 +38,15 @@ export class Payable extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
+    "non_payable_func()"(
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
+
     payable_func(
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
+
+    "payable_func()"(
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
   };
@@ -47,7 +55,15 @@ export class Payable extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
+  "non_payable_func()"(
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
+
   payable_func(overrides?: TransactionOverrides): Promise<ContractTransaction>;
+
+  "payable_func()"(
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
 
   filters: {};
 

--- a/packages/target-ethers-v4/src/codegen/functions.ts
+++ b/packages/target-ethers-v4/src/codegen/functions.ts
@@ -3,10 +3,10 @@ import { generateInputTypes, generateOutputTypes } from './types'
 
 export function codegenFunctions(fns: FunctionDeclaration[]): string {
   if (fns.length === 1) {
-    return generateFunction(fns[0])
+    return `${generateFunction(fns[0])}${codegenForOverloadedFunctions(fns)}`
   }
 
-  return codegenForOverloadedFunctions(fns)
+  return `${generateFunction(fns[0])}${codegenForOverloadedFunctions(fns)}`
 }
 
 export function codegenForOverloadedFunctions(fns: FunctionDeclaration[]): string {

--- a/packages/target-ethers-v5-test/test/DataTypesInput.test.ts
+++ b/packages/target-ethers-v5-test/test/DataTypesInput.test.ts
@@ -35,6 +35,11 @@ describe('DataTypesInput', () => {
       '0x70b144972C5Ef6CB941A5379240B74239c418CD4',
     )
 
+    typedAssert(
+      await contract['input_address(address)']('0x70b144972C5Ef6CB941A5379240B74239c418CD4'),
+      '0x70b144972C5Ef6CB941A5379240B74239c418CD4',
+    )
+
     typedAssert(await contract.input_bytes1('0xaa'), '0xaa')
     typedAssert(await contract.input_bytes1([0]), '0x00')
 

--- a/packages/target-ethers-v5-test/test/Overload.test.ts
+++ b/packages/target-ethers-v5-test/test/Overload.test.ts
@@ -19,7 +19,6 @@ describe('Overloads', () => {
   it('works with 1st overload', async () => {
     typedAssert(await contract['overload1(int256)'](1), BigNumber.from(1))
     typedAssert(await contract.functions['overload1(int256)'](1), { 0: BigNumber.from(1) })
-    expect(contract.overload1).to.be.undefined
   })
 
   it('still doesnt create overload1 fn anymore', () => {

--- a/packages/target-ethers-v5-test/test/Overload.test.ts
+++ b/packages/target-ethers-v5-test/test/Overload.test.ts
@@ -16,12 +16,12 @@ describe('Overloads', () => {
   afterEach(() => ganache.close())
 
   it('works with 1st overload', async () => {
-    const result = await contract['overload1(int256)'](1)
-    typedAssert(result, BigNumber.from(1))
+    typedAssert(await contract['overload1(int256)'](1), BigNumber.from(1))
+    typedAssert(await contract.functions['overload1(int256)'](1), { 0: BigNumber.from(1) })
   })
 
   it('works with 2n overload', async () => {
-    const result = await contract['overload1(uint256,uint256)'](1, 2)
-    typedAssert(result, BigNumber.from(3))
+    typedAssert(await contract['overload1(uint256,uint256)'](1, 2), BigNumber.from(3))
+    typedAssert(await contract.functions['overload1(uint256,uint256)'](1, 2), { 0: BigNumber.from(3) })
   })
 })

--- a/packages/target-ethers-v5-test/test/Overload.test.ts
+++ b/packages/target-ethers-v5-test/test/Overload.test.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai'
 import { typedAssert } from 'test-utils'
 
 import { createNewBlockchain, deployContract } from './common'
@@ -18,6 +19,11 @@ describe('Overloads', () => {
   it('works with 1st overload', async () => {
     typedAssert(await contract['overload1(int256)'](1), BigNumber.from(1))
     typedAssert(await contract.functions['overload1(int256)'](1), { 0: BigNumber.from(1) })
+    expect(contract.overload1).to.be.undefined
+  })
+
+  it('still doesnt create overload1 fn anymore', () => {
+    expect(contract.overload1).to.be.undefined
   })
 
   it('works with 2n overload', async () => {

--- a/packages/target-ethers-v5-test/types/DataTypesInput.d.ts
+++ b/packages/target-ethers-v5-test/types/DataTypesInput.d.ts
@@ -153,7 +153,21 @@ export class DataTypesInput extends Contract {
       0: string;
     }>;
 
+    "input_address(address)"(
+      input1: string,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
     input_bool(
+      input1: boolean,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: boolean;
+    }>;
+
+    "input_bool(bool)"(
       input1: boolean,
       overrides?: CallOverrides
     ): Promise<{
@@ -167,7 +181,21 @@ export class DataTypesInput extends Contract {
       0: string;
     }>;
 
+    "input_bytes(bytes)"(
+      input1: BytesLike,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
     input_bytes1(
+      input1: BytesLike,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
+    "input_bytes1(bytes1)"(
       input1: BytesLike,
       overrides?: CallOverrides
     ): Promise<{
@@ -181,7 +209,21 @@ export class DataTypesInput extends Contract {
       0: number;
     }>;
 
+    "input_enum(uint8)"(
+      input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number;
+    }>;
+
     input_int256(
+      input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+    }>;
+
+    "input_int256(int256)"(
       input1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<{
@@ -195,7 +237,21 @@ export class DataTypesInput extends Contract {
       0: number;
     }>;
 
+    "input_int8(int8)"(
+      input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number;
+    }>;
+
     input_stat_array(
+      input1: BigNumberish[],
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number[];
+    }>;
+
+    "input_stat_array(uint8[3])"(
       input1: BigNumberish[],
       overrides?: CallOverrides
     ): Promise<{
@@ -209,7 +265,26 @@ export class DataTypesInput extends Contract {
       0: string;
     }>;
 
+    "input_string(string)"(
+      input1: string,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
     input_struct(
+      input1: { uint256_0: BigNumberish; uint256_1: BigNumberish },
+      overrides?: CallOverrides
+    ): Promise<{
+      0: {
+        uint256_0: BigNumber;
+        uint256_1: BigNumber;
+        0: BigNumber;
+        1: BigNumber;
+      };
+    }>;
+
+    "input_struct(tuple)"(
       input1: { uint256_0: BigNumberish; uint256_1: BigNumberish },
       overrides?: CallOverrides
     ): Promise<{
@@ -230,7 +305,23 @@ export class DataTypesInput extends Contract {
       1: BigNumber;
     }>;
 
+    "input_tuple(uint256,uint256)"(
+      input1: BigNumberish,
+      input2: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     input_uint256(
+      input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+    }>;
+
+    "input_uint256(uint256)"(
       input1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<{
@@ -243,33 +334,95 @@ export class DataTypesInput extends Contract {
     ): Promise<{
       0: number;
     }>;
+
+    "input_uint8(uint8)"(
+      input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number;
+    }>;
   };
 
   input_address(input1: string, overrides?: CallOverrides): Promise<string>;
 
+  "input_address(address)"(
+    input1: string,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   input_bool(input1: boolean, overrides?: CallOverrides): Promise<boolean>;
+
+  "input_bool(bool)"(
+    input1: boolean,
+    overrides?: CallOverrides
+  ): Promise<boolean>;
 
   input_bytes(input1: BytesLike, overrides?: CallOverrides): Promise<string>;
 
+  "input_bytes(bytes)"(
+    input1: BytesLike,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   input_bytes1(input1: BytesLike, overrides?: CallOverrides): Promise<string>;
 
+  "input_bytes1(bytes1)"(
+    input1: BytesLike,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   input_enum(input1: BigNumberish, overrides?: CallOverrides): Promise<number>;
+
+  "input_enum(uint8)"(
+    input1: BigNumberish,
+    overrides?: CallOverrides
+  ): Promise<number>;
 
   input_int256(
     input1: BigNumberish,
     overrides?: CallOverrides
   ): Promise<BigNumber>;
 
+  "input_int256(int256)"(
+    input1: BigNumberish,
+    overrides?: CallOverrides
+  ): Promise<BigNumber>;
+
   input_int8(input1: BigNumberish, overrides?: CallOverrides): Promise<number>;
+
+  "input_int8(int8)"(
+    input1: BigNumberish,
+    overrides?: CallOverrides
+  ): Promise<number>;
 
   input_stat_array(
     input1: BigNumberish[],
     overrides?: CallOverrides
   ): Promise<number[]>;
 
+  "input_stat_array(uint8[3])"(
+    input1: BigNumberish[],
+    overrides?: CallOverrides
+  ): Promise<number[]>;
+
   input_string(input1: string, overrides?: CallOverrides): Promise<string>;
 
+  "input_string(string)"(
+    input1: string,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   input_struct(
+    input1: { uint256_0: BigNumberish; uint256_1: BigNumberish },
+    overrides?: CallOverrides
+  ): Promise<{
+    uint256_0: BigNumber;
+    uint256_1: BigNumber;
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
+  "input_struct(tuple)"(
     input1: { uint256_0: BigNumberish; uint256_1: BigNumberish },
     overrides?: CallOverrides
   ): Promise<{
@@ -288,23 +441,67 @@ export class DataTypesInput extends Contract {
     1: BigNumber;
   }>;
 
+  "input_tuple(uint256,uint256)"(
+    input1: BigNumberish,
+    input2: BigNumberish,
+    overrides?: CallOverrides
+  ): Promise<{
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
   input_uint256(
+    input1: BigNumberish,
+    overrides?: CallOverrides
+  ): Promise<BigNumber>;
+
+  "input_uint256(uint256)"(
     input1: BigNumberish,
     overrides?: CallOverrides
   ): Promise<BigNumber>;
 
   input_uint8(input1: BigNumberish, overrides?: CallOverrides): Promise<number>;
 
+  "input_uint8(uint8)"(
+    input1: BigNumberish,
+    overrides?: CallOverrides
+  ): Promise<number>;
+
   callStatic: {
     input_address(input1: string, overrides?: CallOverrides): Promise<string>;
 
+    "input_address(address)"(
+      input1: string,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
     input_bool(input1: boolean, overrides?: CallOverrides): Promise<boolean>;
+
+    "input_bool(bool)"(
+      input1: boolean,
+      overrides?: CallOverrides
+    ): Promise<boolean>;
 
     input_bytes(input1: BytesLike, overrides?: CallOverrides): Promise<string>;
 
+    "input_bytes(bytes)"(
+      input1: BytesLike,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
     input_bytes1(input1: BytesLike, overrides?: CallOverrides): Promise<string>;
 
+    "input_bytes1(bytes1)"(
+      input1: BytesLike,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
     input_enum(
+      input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<number>;
+
+    "input_enum(uint8)"(
       input1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<number>;
@@ -314,7 +511,17 @@ export class DataTypesInput extends Contract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    "input_int256(int256)"(
+      input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     input_int8(
+      input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<number>;
+
+    "input_int8(int8)"(
       input1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<number>;
@@ -324,9 +531,29 @@ export class DataTypesInput extends Contract {
       overrides?: CallOverrides
     ): Promise<number[]>;
 
+    "input_stat_array(uint8[3])"(
+      input1: BigNumberish[],
+      overrides?: CallOverrides
+    ): Promise<number[]>;
+
     input_string(input1: string, overrides?: CallOverrides): Promise<string>;
 
+    "input_string(string)"(
+      input1: string,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
     input_struct(
+      input1: { uint256_0: BigNumberish; uint256_1: BigNumberish },
+      overrides?: CallOverrides
+    ): Promise<{
+      uint256_0: BigNumber;
+      uint256_1: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
+    "input_struct(tuple)"(
       input1: { uint256_0: BigNumberish; uint256_1: BigNumberish },
       overrides?: CallOverrides
     ): Promise<{
@@ -345,12 +572,31 @@ export class DataTypesInput extends Contract {
       1: BigNumber;
     }>;
 
+    "input_tuple(uint256,uint256)"(
+      input1: BigNumberish,
+      input2: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     input_uint256(
       input1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    "input_uint256(uint256)"(
+      input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     input_uint8(
+      input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<number>;
+
+    "input_uint8(uint8)"(
       input1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<number>;

--- a/packages/target-ethers-v5-test/types/DataTypesPure.d.ts
+++ b/packages/target-ethers-v5-test/types/DataTypesPure.d.ts
@@ -143,7 +143,19 @@ export class DataTypesPure extends Contract {
       0: string;
     }>;
 
+    "pure_address()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
     pure_bool(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: boolean;
+    }>;
+
+    "pure_bool()"(
       overrides?: CallOverrides
     ): Promise<{
       0: boolean;
@@ -155,7 +167,19 @@ export class DataTypesPure extends Contract {
       0: string;
     }>;
 
+    "pure_bytes()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
     pure_bytes1(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
+    "pure_bytes1()"(
       overrides?: CallOverrides
     ): Promise<{
       0: string;
@@ -167,13 +191,31 @@ export class DataTypesPure extends Contract {
       0: number;
     }>;
 
+    "pure_enum()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number;
+    }>;
+
     pure_int256(
       overrides?: CallOverrides
     ): Promise<{
       0: BigNumber;
     }>;
 
+    "pure_int256()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+    }>;
+
     pure_int8(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number;
+    }>;
+
+    "pure_int8()"(
       overrides?: CallOverrides
     ): Promise<{
       0: number;
@@ -188,7 +230,22 @@ export class DataTypesPure extends Contract {
       1: BigNumber;
     }>;
 
+    "pure_named()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      uint256_1: BigNumber;
+      uint256_2: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     pure_stat_array(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number[];
+    }>;
+
+    "pure_stat_array()"(
       overrides?: CallOverrides
     ): Promise<{
       0: number[];
@@ -200,7 +257,24 @@ export class DataTypesPure extends Contract {
       0: string;
     }>;
 
+    "pure_string()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
     pure_struct(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: {
+        uint256_0: BigNumber;
+        uint256_1: BigNumber;
+        0: BigNumber;
+        1: BigNumber;
+      };
+    }>;
+
+    "pure_struct()"(
       overrides?: CallOverrides
     ): Promise<{
       0: {
@@ -218,7 +292,20 @@ export class DataTypesPure extends Contract {
       1: BigNumber;
     }>;
 
+    "pure_tuple()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     pure_uint256(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+    }>;
+
+    "pure_uint256()"(
       overrides?: CallOverrides
     ): Promise<{
       0: BigNumber;
@@ -229,21 +316,41 @@ export class DataTypesPure extends Contract {
     ): Promise<{
       0: number;
     }>;
+
+    "pure_uint8()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number;
+    }>;
   };
 
   pure_address(overrides?: CallOverrides): Promise<string>;
 
+  "pure_address()"(overrides?: CallOverrides): Promise<string>;
+
   pure_bool(overrides?: CallOverrides): Promise<boolean>;
+
+  "pure_bool()"(overrides?: CallOverrides): Promise<boolean>;
 
   pure_bytes(overrides?: CallOverrides): Promise<string>;
 
+  "pure_bytes()"(overrides?: CallOverrides): Promise<string>;
+
   pure_bytes1(overrides?: CallOverrides): Promise<string>;
+
+  "pure_bytes1()"(overrides?: CallOverrides): Promise<string>;
 
   pure_enum(overrides?: CallOverrides): Promise<number>;
 
+  "pure_enum()"(overrides?: CallOverrides): Promise<number>;
+
   pure_int256(overrides?: CallOverrides): Promise<BigNumber>;
 
+  "pure_int256()"(overrides?: CallOverrides): Promise<BigNumber>;
+
   pure_int8(overrides?: CallOverrides): Promise<number>;
+
+  "pure_int8()"(overrides?: CallOverrides): Promise<number>;
 
   pure_named(
     overrides?: CallOverrides
@@ -254,11 +361,33 @@ export class DataTypesPure extends Contract {
     1: BigNumber;
   }>;
 
+  "pure_named()"(
+    overrides?: CallOverrides
+  ): Promise<{
+    uint256_1: BigNumber;
+    uint256_2: BigNumber;
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
   pure_stat_array(overrides?: CallOverrides): Promise<number[]>;
+
+  "pure_stat_array()"(overrides?: CallOverrides): Promise<number[]>;
 
   pure_string(overrides?: CallOverrides): Promise<string>;
 
+  "pure_string()"(overrides?: CallOverrides): Promise<string>;
+
   pure_struct(
+    overrides?: CallOverrides
+  ): Promise<{
+    uint256_0: BigNumber;
+    uint256_1: BigNumber;
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
+  "pure_struct()"(
     overrides?: CallOverrides
   ): Promise<{
     uint256_0: BigNumber;
@@ -274,24 +403,49 @@ export class DataTypesPure extends Contract {
     1: BigNumber;
   }>;
 
+  "pure_tuple()"(
+    overrides?: CallOverrides
+  ): Promise<{
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
   pure_uint256(overrides?: CallOverrides): Promise<BigNumber>;
 
+  "pure_uint256()"(overrides?: CallOverrides): Promise<BigNumber>;
+
   pure_uint8(overrides?: CallOverrides): Promise<number>;
+
+  "pure_uint8()"(overrides?: CallOverrides): Promise<number>;
 
   callStatic: {
     pure_address(overrides?: CallOverrides): Promise<string>;
 
+    "pure_address()"(overrides?: CallOverrides): Promise<string>;
+
     pure_bool(overrides?: CallOverrides): Promise<boolean>;
+
+    "pure_bool()"(overrides?: CallOverrides): Promise<boolean>;
 
     pure_bytes(overrides?: CallOverrides): Promise<string>;
 
+    "pure_bytes()"(overrides?: CallOverrides): Promise<string>;
+
     pure_bytes1(overrides?: CallOverrides): Promise<string>;
+
+    "pure_bytes1()"(overrides?: CallOverrides): Promise<string>;
 
     pure_enum(overrides?: CallOverrides): Promise<number>;
 
+    "pure_enum()"(overrides?: CallOverrides): Promise<number>;
+
     pure_int256(overrides?: CallOverrides): Promise<BigNumber>;
 
+    "pure_int256()"(overrides?: CallOverrides): Promise<BigNumber>;
+
     pure_int8(overrides?: CallOverrides): Promise<number>;
+
+    "pure_int8()"(overrides?: CallOverrides): Promise<number>;
 
     pure_named(
       overrides?: CallOverrides
@@ -302,11 +456,33 @@ export class DataTypesPure extends Contract {
       1: BigNumber;
     }>;
 
+    "pure_named()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      uint256_1: BigNumber;
+      uint256_2: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     pure_stat_array(overrides?: CallOverrides): Promise<number[]>;
+
+    "pure_stat_array()"(overrides?: CallOverrides): Promise<number[]>;
 
     pure_string(overrides?: CallOverrides): Promise<string>;
 
+    "pure_string()"(overrides?: CallOverrides): Promise<string>;
+
     pure_struct(
+      overrides?: CallOverrides
+    ): Promise<{
+      uint256_0: BigNumber;
+      uint256_1: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
+    "pure_struct()"(
       overrides?: CallOverrides
     ): Promise<{
       uint256_0: BigNumber;
@@ -322,9 +498,20 @@ export class DataTypesPure extends Contract {
       1: BigNumber;
     }>;
 
+    "pure_tuple()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     pure_uint256(overrides?: CallOverrides): Promise<BigNumber>;
 
+    "pure_uint256()"(overrides?: CallOverrides): Promise<BigNumber>;
+
     pure_uint8(overrides?: CallOverrides): Promise<number>;
+
+    "pure_uint8()"(overrides?: CallOverrides): Promise<number>;
   };
 
   filters: {};

--- a/packages/target-ethers-v5-test/types/DataTypesView.d.ts
+++ b/packages/target-ethers-v5-test/types/DataTypesView.d.ts
@@ -143,7 +143,19 @@ export class DataTypesView extends Contract {
       0: string;
     }>;
 
+    "view_address()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
     view_bool(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: boolean;
+    }>;
+
+    "view_bool()"(
       overrides?: CallOverrides
     ): Promise<{
       0: boolean;
@@ -155,7 +167,19 @@ export class DataTypesView extends Contract {
       0: string;
     }>;
 
+    "view_bytes()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
     view_bytes1(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
+    "view_bytes1()"(
       overrides?: CallOverrides
     ): Promise<{
       0: string;
@@ -167,13 +191,31 @@ export class DataTypesView extends Contract {
       0: number;
     }>;
 
+    "view_enum()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number;
+    }>;
+
     view_int256(
       overrides?: CallOverrides
     ): Promise<{
       0: BigNumber;
     }>;
 
+    "view_int256()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+    }>;
+
     view_int8(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number;
+    }>;
+
+    "view_int8()"(
       overrides?: CallOverrides
     ): Promise<{
       0: number;
@@ -188,7 +230,22 @@ export class DataTypesView extends Contract {
       1: BigNumber;
     }>;
 
+    "view_named()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      uint256_1: BigNumber;
+      uint256_2: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     view_stat_array(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number[];
+    }>;
+
+    "view_stat_array()"(
       overrides?: CallOverrides
     ): Promise<{
       0: number[];
@@ -200,7 +257,24 @@ export class DataTypesView extends Contract {
       0: string;
     }>;
 
+    "view_string()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: string;
+    }>;
+
     view_struct(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: {
+        uint256_0: BigNumber;
+        uint256_1: BigNumber;
+        0: BigNumber;
+        1: BigNumber;
+      };
+    }>;
+
+    "view_struct()"(
       overrides?: CallOverrides
     ): Promise<{
       0: {
@@ -218,7 +292,20 @@ export class DataTypesView extends Contract {
       1: BigNumber;
     }>;
 
+    "view_tuple()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     view_uint256(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+    }>;
+
+    "view_uint256()"(
       overrides?: CallOverrides
     ): Promise<{
       0: BigNumber;
@@ -229,21 +316,41 @@ export class DataTypesView extends Contract {
     ): Promise<{
       0: number;
     }>;
+
+    "view_uint8()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: number;
+    }>;
   };
 
   view_address(overrides?: CallOverrides): Promise<string>;
 
+  "view_address()"(overrides?: CallOverrides): Promise<string>;
+
   view_bool(overrides?: CallOverrides): Promise<boolean>;
+
+  "view_bool()"(overrides?: CallOverrides): Promise<boolean>;
 
   view_bytes(overrides?: CallOverrides): Promise<string>;
 
+  "view_bytes()"(overrides?: CallOverrides): Promise<string>;
+
   view_bytes1(overrides?: CallOverrides): Promise<string>;
+
+  "view_bytes1()"(overrides?: CallOverrides): Promise<string>;
 
   view_enum(overrides?: CallOverrides): Promise<number>;
 
+  "view_enum()"(overrides?: CallOverrides): Promise<number>;
+
   view_int256(overrides?: CallOverrides): Promise<BigNumber>;
 
+  "view_int256()"(overrides?: CallOverrides): Promise<BigNumber>;
+
   view_int8(overrides?: CallOverrides): Promise<number>;
+
+  "view_int8()"(overrides?: CallOverrides): Promise<number>;
 
   view_named(
     overrides?: CallOverrides
@@ -254,11 +361,33 @@ export class DataTypesView extends Contract {
     1: BigNumber;
   }>;
 
+  "view_named()"(
+    overrides?: CallOverrides
+  ): Promise<{
+    uint256_1: BigNumber;
+    uint256_2: BigNumber;
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
   view_stat_array(overrides?: CallOverrides): Promise<number[]>;
+
+  "view_stat_array()"(overrides?: CallOverrides): Promise<number[]>;
 
   view_string(overrides?: CallOverrides): Promise<string>;
 
+  "view_string()"(overrides?: CallOverrides): Promise<string>;
+
   view_struct(
+    overrides?: CallOverrides
+  ): Promise<{
+    uint256_0: BigNumber;
+    uint256_1: BigNumber;
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
+  "view_struct()"(
     overrides?: CallOverrides
   ): Promise<{
     uint256_0: BigNumber;
@@ -274,24 +403,49 @@ export class DataTypesView extends Contract {
     1: BigNumber;
   }>;
 
+  "view_tuple()"(
+    overrides?: CallOverrides
+  ): Promise<{
+    0: BigNumber;
+    1: BigNumber;
+  }>;
+
   view_uint256(overrides?: CallOverrides): Promise<BigNumber>;
 
+  "view_uint256()"(overrides?: CallOverrides): Promise<BigNumber>;
+
   view_uint8(overrides?: CallOverrides): Promise<number>;
+
+  "view_uint8()"(overrides?: CallOverrides): Promise<number>;
 
   callStatic: {
     view_address(overrides?: CallOverrides): Promise<string>;
 
+    "view_address()"(overrides?: CallOverrides): Promise<string>;
+
     view_bool(overrides?: CallOverrides): Promise<boolean>;
+
+    "view_bool()"(overrides?: CallOverrides): Promise<boolean>;
 
     view_bytes(overrides?: CallOverrides): Promise<string>;
 
+    "view_bytes()"(overrides?: CallOverrides): Promise<string>;
+
     view_bytes1(overrides?: CallOverrides): Promise<string>;
+
+    "view_bytes1()"(overrides?: CallOverrides): Promise<string>;
 
     view_enum(overrides?: CallOverrides): Promise<number>;
 
+    "view_enum()"(overrides?: CallOverrides): Promise<number>;
+
     view_int256(overrides?: CallOverrides): Promise<BigNumber>;
 
+    "view_int256()"(overrides?: CallOverrides): Promise<BigNumber>;
+
     view_int8(overrides?: CallOverrides): Promise<number>;
+
+    "view_int8()"(overrides?: CallOverrides): Promise<number>;
 
     view_named(
       overrides?: CallOverrides
@@ -302,11 +456,33 @@ export class DataTypesView extends Contract {
       1: BigNumber;
     }>;
 
+    "view_named()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      uint256_1: BigNumber;
+      uint256_2: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     view_stat_array(overrides?: CallOverrides): Promise<number[]>;
+
+    "view_stat_array()"(overrides?: CallOverrides): Promise<number[]>;
 
     view_string(overrides?: CallOverrides): Promise<string>;
 
+    "view_string()"(overrides?: CallOverrides): Promise<string>;
+
     view_struct(
+      overrides?: CallOverrides
+    ): Promise<{
+      uint256_0: BigNumber;
+      uint256_1: BigNumber;
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
+    "view_struct()"(
       overrides?: CallOverrides
     ): Promise<{
       uint256_0: BigNumber;
@@ -322,9 +498,20 @@ export class DataTypesView extends Contract {
       1: BigNumber;
     }>;
 
+    "view_tuple()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: BigNumber;
+      1: BigNumber;
+    }>;
+
     view_uint256(overrides?: CallOverrides): Promise<BigNumber>;
 
+    "view_uint256()"(overrides?: CallOverrides): Promise<BigNumber>;
+
     view_uint8(overrides?: CallOverrides): Promise<number>;
+
+    "view_uint8()"(overrides?: CallOverrides): Promise<number>;
   };
 
   filters: {};

--- a/packages/target-ethers-v5-test/types/Events.d.ts
+++ b/packages/target-ethers-v5-test/types/Events.d.ts
@@ -95,35 +95,69 @@ export class Events extends Contract {
   functions: {
     emit_anon1(overrides?: Overrides): Promise<ContractTransaction>;
 
+    "emit_anon1()"(overrides?: Overrides): Promise<ContractTransaction>;
+
     emit_event1(overrides?: Overrides): Promise<ContractTransaction>;
+
+    "emit_event1()"(overrides?: Overrides): Promise<ContractTransaction>;
 
     emit_event2(overrides?: Overrides): Promise<ContractTransaction>;
 
+    "emit_event2()"(overrides?: Overrides): Promise<ContractTransaction>;
+
     emit_event3(overrides?: Overrides): Promise<ContractTransaction>;
 
+    "emit_event3()"(overrides?: Overrides): Promise<ContractTransaction>;
+
     emit_event3_overloaded(overrides?: Overrides): Promise<ContractTransaction>;
+
+    "emit_event3_overloaded()"(
+      overrides?: Overrides
+    ): Promise<ContractTransaction>;
   };
 
   emit_anon1(overrides?: Overrides): Promise<ContractTransaction>;
 
+  "emit_anon1()"(overrides?: Overrides): Promise<ContractTransaction>;
+
   emit_event1(overrides?: Overrides): Promise<ContractTransaction>;
+
+  "emit_event1()"(overrides?: Overrides): Promise<ContractTransaction>;
 
   emit_event2(overrides?: Overrides): Promise<ContractTransaction>;
 
+  "emit_event2()"(overrides?: Overrides): Promise<ContractTransaction>;
+
   emit_event3(overrides?: Overrides): Promise<ContractTransaction>;
 
+  "emit_event3()"(overrides?: Overrides): Promise<ContractTransaction>;
+
   emit_event3_overloaded(overrides?: Overrides): Promise<ContractTransaction>;
+
+  "emit_event3_overloaded()"(
+    overrides?: Overrides
+  ): Promise<ContractTransaction>;
 
   callStatic: {
     emit_anon1(overrides?: Overrides): Promise<void>;
 
+    "emit_anon1()"(overrides?: Overrides): Promise<void>;
+
     emit_event1(overrides?: Overrides): Promise<void>;
+
+    "emit_event1()"(overrides?: Overrides): Promise<void>;
 
     emit_event2(overrides?: Overrides): Promise<void>;
 
+    "emit_event2()"(overrides?: Overrides): Promise<void>;
+
     emit_event3(overrides?: Overrides): Promise<void>;
 
+    "emit_event3()"(overrides?: Overrides): Promise<void>;
+
     emit_event3_overloaded(overrides?: Overrides): Promise<void>;
+
+    "emit_event3_overloaded()"(overrides?: Overrides): Promise<void>;
   };
 
   filters: {

--- a/packages/target-ethers-v5-test/types/NameMangling.d.ts
+++ b/packages/target-ethers-v5-test/types/NameMangling.d.ts
@@ -49,12 +49,22 @@ export class NameMangling extends Contract {
     ): Promise<{
       0: boolean;
     }>;
+
+    "works()"(
+      overrides?: CallOverrides
+    ): Promise<{
+      0: boolean;
+    }>;
   };
 
   works(overrides?: CallOverrides): Promise<boolean>;
 
+  "works()"(overrides?: CallOverrides): Promise<boolean>;
+
   callStatic: {
     works(overrides?: CallOverrides): Promise<boolean>;
+
+    "works()"(overrides?: CallOverrides): Promise<boolean>;
   };
 
   filters: {};

--- a/packages/target-ethers-v5-test/types/Payable.d.ts
+++ b/packages/target-ethers-v5-test/types/Payable.d.ts
@@ -62,17 +62,31 @@ export class Payable extends Contract {
   functions: {
     non_payable_func(overrides?: Overrides): Promise<ContractTransaction>;
 
+    "non_payable_func()"(overrides?: Overrides): Promise<ContractTransaction>;
+
     payable_func(overrides?: PayableOverrides): Promise<ContractTransaction>;
+
+    "payable_func()"(
+      overrides?: PayableOverrides
+    ): Promise<ContractTransaction>;
   };
 
   non_payable_func(overrides?: Overrides): Promise<ContractTransaction>;
 
+  "non_payable_func()"(overrides?: Overrides): Promise<ContractTransaction>;
+
   payable_func(overrides?: PayableOverrides): Promise<ContractTransaction>;
+
+  "payable_func()"(overrides?: PayableOverrides): Promise<ContractTransaction>;
 
   callStatic: {
     non_payable_func(overrides?: Overrides): Promise<void>;
 
+    "non_payable_func()"(overrides?: Overrides): Promise<void>;
+
     payable_func(overrides?: PayableOverrides): Promise<void>;
+
+    "payable_func()"(overrides?: PayableOverrides): Promise<void>;
   };
 
   filters: {};

--- a/packages/target-ethers-v5/src/codegen/functions.ts
+++ b/packages/target-ethers-v5/src/codegen/functions.ts
@@ -8,7 +8,7 @@ interface GenerateFunctionOptions {
 
 export function codegenFunctions(options: GenerateFunctionOptions, fns: FunctionDeclaration[]): string {
   if (fns.length === 1) {
-    return generateFunction(options, fns[0])
+    return `${generateFunction(options, fns[0])}${codegenForOverloadedFunctions(options, fns)}`
   }
 
   return codegenForOverloadedFunctions(options, fns)


### PR DESCRIPTION
According to the discussions in [this topic](https://github.com/ethers-io/ethers.js/issues/407) overloads work a bit differently than they were being typed:

- in `ethers-v4` overloads will use the first defined as the normal fn (`contract.overload1(1)`) and will ALWAYS have `contract['overload1(int256)'](1)`
- in `ethers-v5` overloads will **only** provide the latter if they are detected so that `contract.overload1(1)` is not available.  

I added some extra testing to confirm this was the appropriate behavior as well.  

> i added a case for `ethers-v5` that will continually confirm they have not changed back to the `v4` behavior by expecting the `contract.overload1` to be undefined explicitly. 

> Additionally, I created tests for both v4 and v5 which tests against and confirms the behavior differences -- in v4 `contract.functions.method()` returns the same as a normal `contract.method()` but v5 returns `[Result]` for `contract.functions.method()` 

This should start working properly when combined with my other PR's as well for the other areas, but work adding some tests once they are all a family :-)

---

The 3 PR's combined, which we are using to generate working types for our contracts is https://github.com/bradennapier/TypeChain/tree/combined-prs