### PR TITLE
Fix callStatic overrides for non constant fns

### DIFF
--- a/packages/target-ethers-v5/src/codegen/functions.ts
+++ b/packages/target-ethers-v5/src/codegen/functions.ts
@@ -26,7 +26,7 @@ function generateFunction(options: GenerateFunctionOptions, fn: FunctionDeclarat
   return `
   ${generateFunctionDocumentation(fn.documentation)}
   ${overloadedName ?? fn.name}(${generateInputTypes(fn.inputs)}${
-    !isConstant(fn) && !isConstantFn(fn)
+    !options.isStaticCall && !isConstant(fn) && !isConstantFn(fn)
       ? `overrides?: ${isPayable(fn) ? 'PayableOverrides' : 'Overrides'}`
       : 'overrides?: CallOverrides'
   }): Promise<${


### PR DESCRIPTION
Before:

```typescript
callStatic: {
    getValue(overrides?: CallOverrides): Promise<string>;
    setValue(overrides?: Overrides): Promise<string>;
}
```

After:

```typescript
callStatic: {
    getValue(overrides?: CallOverrides): Promise<string>;
    setValue(overrides?: CallOverrides): Promise<string>;
}
```

In `CallOverrides` we can pass `from` property, which can be passed to non constant methods under `callStatic` bucket. Until now only constant methods were having the `CallOverrides` overrides. This PR fixes the specific case bug.

Testing: I've ran this PR in two of my projects with no breakings. However, to be more sure, can someone try in their project? It'd be great.