### PR TITLE
Fix CallOverrides not imported

### DIFF
--- a/packages/target-ethers-v5-test/types/Events.d.ts
+++ b/packages/target-ethers-v5-test/types/Events.d.ts
@@ -12,7 +12,8 @@ import {
 import {
   Contract,
   ContractTransaction,
-  Overrides
+  Overrides,
+  CallOverrides
 } from "@ethersproject/contracts";
 import { BytesLike } from "@ethersproject/bytes";
 import { Listener, Provider } from "@ethersproject/providers";

--- a/packages/target-ethers-v5-test/types/Payable.d.ts
+++ b/packages/target-ethers-v5-test/types/Payable.d.ts
@@ -13,7 +13,8 @@ import {
   Contract,
   ContractTransaction,
   Overrides,
-  PayableOverrides
+  PayableOverrides,
+  CallOverrides
 } from "@ethersproject/contracts";
 import { BytesLike } from "@ethersproject/bytes";
 import { Listener, Provider } from "@ethersproject/providers";

--- a/packages/target-ethers-v5/src/codegen/index.ts
+++ b/packages/target-ethers-v5/src/codegen/index.ts
@@ -13,7 +13,7 @@ import { codegenFunctions } from './functions'
 export function codegenContractTypings(contract: Contract) {
   const contractImports: string[] = ['Contract', 'ContractTransaction']
   const allFunctions = values(contract.functions)
-    .map(codegenFunctions.bind(null, { returnResultObject: true }))
+    .map((fn) => codegenFunctions({ returnResultObject: true }, fn) + codegenFunctions({ isStaticCall: true }, fn))
     .join('')
 
   const optionalContractImports = ['Overrides', 'PayableOverrides', 'CallOverrides']


### PR DESCRIPTION
This PR fixes a bug described in https://github.com/ethereum-ts/TypeChain/pull/258#issuecomment-660537576