### PR TITLE
[ethers-v5] Export contract types in index.ts

### DIFF
--- a/packages/target-ethers-v5/src/codegen/index.ts
+++ b/packages/target-ethers-v5/src/codegen/index.ts
@@ -132,7 +132,7 @@ export function codegenContractFactory(contract: Contract, abi: any, bytecode?: 
   import { Provider, TransactionRequest } from '@ethersproject/providers';
   import { ${ethersContractImports.join(', ')} } from "@ethersproject/contracts";
 
-  import { ${contract.name} } from "./${contract.name}";
+  import type { ${contract.name} } from "./${contract.name}";
 
   export class ${contract.name}Factory extends ContractFactory {
     ${generateFactoryConstructor(contract, bytecode)}
@@ -166,7 +166,7 @@ export function codegenAbstractContractFactory(contract: Contract, abi: any): st
   import { Contract, Signer } from "ethers";
   import { Provider } from "@ethersproject/providers";
 
-  import { ${contract.name} } from "./${contract.name}";
+  import type { ${contract.name} } from "./${contract.name}";
 
   export class ${contract.name}Factory {
     static connect(address: string, signerOrProvider: Signer | Provider): ${contract.name} {

--- a/packages/target-ethers-v5/src/index.ts
+++ b/packages/target-ethers-v5/src/index.ts
@@ -125,7 +125,14 @@ export default class Ethers extends TsGeneratorPlugin {
       ...abstractFactoryFiles,
       {
         path: join(this.outDirAbs, 'index.ts'),
-        contents: this.contractFiles.map((fileName) => `export * from './${fileName}Factory'`).join('\n'),
+        contents: this.contractFiles
+          .map((fileName) =>
+            [
+              `export { ${fileName}Factory } from './${fileName}Factory'`,
+              `export type { ${fileName} } from './${fileName}'`,
+            ].join('\n'),
+          )
+          .join('\n'),
       },
     ]
   }


### PR DESCRIPTION
#278

Before:
```
<Contract>.d.ts
<Contract>Factory.ts
```

Only Factory file was exported

After:
```
<Contract>.ts
<Contract>Factory.ts
```

Now both the ts files are exported from `index.ts`

I've tried this PR on my current project, and didn't get any breakings. Though it can be tried on multiple projects to be sure.