### PR TITLE
Don't enforce camel case

### DIFF
--- a/packages/typechain/src/parser/normalizeName.ts
+++ b/packages/typechain/src/parser/normalizeName.ts
@@ -6,7 +6,7 @@ import { upperFirst, camelCase } from 'lodash'
 export function normalizeName(rawName: string): string {
   const t1 = rawName.split(' ').join('-') // spaces to - so later we can automatically convert them
   const t2 = t1.replace(/^\d+/, '') // removes leading digits
-  const result = upperFirst(camelCase(t2))
+  const result = upperFirst(t2)
 
   if (result === '') {
     throw new Error(`Can't guess class name, please rename file: ${rawName}`)


### PR DESCRIPTION
The enforced camel casing breaks existing standard names like `ERC20.sol` and make the typings look like `Erc20.d.ts`, which adds complexity and confusion and requires unnecessary work to use typechain@2.0.