### PR TITLE
[ethers-v4/5] Respect reserved keywords while generating top-level typings

### DIFF
--- a/.changeset/smart-ants-begin.md
+++ b/.changeset/smart-ants-begin.md
@@ -1,0 +1,6 @@
+---
+'@typechain/ethers-v4': patch
+'@typechain/ethers-v5': patch
+---
+
+Do not generate typings in contract type itself for reserved keywords that would collide with ethers internals

--- a/contracts/Name-Mangling.sol
+++ b/contracts/Name-Mangling.sol
@@ -1,10 +1,14 @@
-
 pragma solidity ^0.6.4;
 pragma experimental ABIEncoderV2;
 
 // useful during integration testing with truffle
 contract NAME12mangling {
   function works() public view returns (bool) {
+    return true;
+  }
+
+  // test name collision
+  function provider() public view returns (bool) {
     return true;
   }
 }

--- a/packages/target-ethers-v4-test/types/NameMangling.d.ts
+++ b/packages/target-ethers-v4-test/types/NameMangling.d.ts
@@ -13,6 +13,8 @@ import {
 
 interface NameManglingInterface extends Interface {
   functions: {
+    provider: TypedFunctionDescription<{ encode([]: []): string }>;
+
     works: TypedFunctionDescription<{ encode([]: []): string }>;
   };
 
@@ -36,6 +38,10 @@ export class NameMangling extends Contract {
   interface: NameManglingInterface;
 
   functions: {
+    provider(overrides?: TransactionOverrides): Promise<boolean>;
+
+    "provider()"(overrides?: TransactionOverrides): Promise<boolean>;
+
     works(overrides?: TransactionOverrides): Promise<boolean>;
 
     "works()"(overrides?: TransactionOverrides): Promise<boolean>;
@@ -48,6 +54,10 @@ export class NameMangling extends Contract {
   filters: {};
 
   estimate: {
+    provider(overrides?: TransactionOverrides): Promise<BigNumber>;
+
+    "provider()"(overrides?: TransactionOverrides): Promise<BigNumber>;
+
     works(overrides?: TransactionOverrides): Promise<BigNumber>;
 
     "works()"(overrides?: TransactionOverrides): Promise<BigNumber>;

--- a/packages/target-ethers-v4-test/types/factories/NameMangling__factory.ts
+++ b/packages/target-ethers-v4-test/types/factories/NameMangling__factory.ts
@@ -19,6 +19,19 @@ export class NameMangling__factory {
 const _abi = [
   {
     inputs: [],
+    name: "provider",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
     name: "works",
     outputs: [
       {

--- a/packages/target-ethers-v4/src/codegen/index.ts
+++ b/packages/target-ethers-v4/src/codegen/index.ts
@@ -10,6 +10,7 @@ import {
 import { generateInputType, generateInputTypes } from './types'
 import { codegenFunctions } from './functions'
 import { FACTORY_POSTFIX } from '../common'
+import { reservedKeywords } from './reserved-keywords'
 
 export function codegenContractTypings(contract: Contract) {
   const template = `
@@ -51,7 +52,10 @@ export function codegenContractTypings(contract: Contract) {
       ${values(contract.functions).map(codegenFunctions.bind(null, {})).join('\n')}
     };
 
-    ${values(contract.functions).map(codegenFunctions.bind(null, {})).join('\n')}
+    ${values(contract.functions)
+      .filter((f) => !reservedKeywords.has(f[0].name))
+      .map(codegenFunctions.bind(null, {}))
+      .join('\n')}
 
     filters: {
       ${values(contract.events)

--- a/packages/target-ethers-v4/src/codegen/reserved-keywords.ts
+++ b/packages/target-ethers-v4/src/codegen/reserved-keywords.ts
@@ -1,0 +1,1 @@
+export const reservedKeywords = new Set(['signer', 'provider', 'deployTransaction', 'deployed', 'fallback', 'connect'])

--- a/packages/target-ethers-v5-test/types/NameMangling.d.ts
+++ b/packages/target-ethers-v5-test/types/NameMangling.d.ts
@@ -21,11 +21,14 @@ import { FunctionFragment, EventFragment, Result } from "@ethersproject/abi";
 
 interface NameManglingInterface extends ethers.utils.Interface {
   functions: {
+    "provider()": FunctionFragment;
     "works()": FunctionFragment;
   };
 
+  encodeFunctionData(functionFragment: "provider", values?: undefined): string;
   encodeFunctionData(functionFragment: "works", values?: undefined): string;
 
+  decodeFunctionResult(functionFragment: "provider", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "works", data: BytesLike): Result;
 
   events: {};
@@ -45,6 +48,10 @@ export class NameMangling extends Contract {
   interface: NameManglingInterface;
 
   functions: {
+    provider(overrides?: CallOverrides): Promise<[boolean]>;
+
+    "provider()"(overrides?: CallOverrides): Promise<[boolean]>;
+
     works(overrides?: CallOverrides): Promise<[boolean]>;
 
     "works()"(overrides?: CallOverrides): Promise<[boolean]>;
@@ -55,6 +62,10 @@ export class NameMangling extends Contract {
   "works()"(overrides?: CallOverrides): Promise<boolean>;
 
   callStatic: {
+    provider(overrides?: CallOverrides): Promise<boolean>;
+
+    "provider()"(overrides?: CallOverrides): Promise<boolean>;
+
     works(overrides?: CallOverrides): Promise<boolean>;
 
     "works()"(overrides?: CallOverrides): Promise<boolean>;
@@ -63,12 +74,20 @@ export class NameMangling extends Contract {
   filters: {};
 
   estimateGas: {
+    provider(overrides?: CallOverrides): Promise<BigNumber>;
+
+    "provider()"(overrides?: CallOverrides): Promise<BigNumber>;
+
     works(overrides?: CallOverrides): Promise<BigNumber>;
 
     "works()"(overrides?: CallOverrides): Promise<BigNumber>;
   };
 
   populateTransaction: {
+    provider(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    "provider()"(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
     works(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     "works()"(overrides?: CallOverrides): Promise<PopulatedTransaction>;

--- a/packages/target-ethers-v5-test/types/factories/NameMangling__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/NameMangling__factory.ts
@@ -19,6 +19,19 @@ export class NameMangling__factory {
 const _abi = [
   {
     inputs: [],
+    name: "provider",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
     name: "works",
     outputs: [
       {

--- a/packages/target-ethers-v5/src/codegen/index.ts
+++ b/packages/target-ethers-v5/src/codegen/index.ts
@@ -10,6 +10,7 @@ import {
 import { generateInputType, generateInputTypes } from './types'
 import { codegenFunctions } from './functions'
 import { FACTORY_POSTFIX } from '../common'
+import { reservedKeywords } from './reserved-keywords'
 
 export function codegenContractTypings(contract: Contract) {
   const contractImports: string[] = ['Contract', 'ContractTransaction']
@@ -77,7 +78,10 @@ export function codegenContractTypings(contract: Contract) {
         .join('\n')}
     };
 
-    ${values(contract.functions).map(codegenFunctions.bind(null, {})).join('\n')}
+    ${values(contract.functions)
+      .filter((f) => !reservedKeywords.has(f[0].name))
+      .map(codegenFunctions.bind(null, {}))
+      .join('\n')}
 
     callStatic: {
       ${values(contract.functions)

--- a/packages/target-ethers-v5/src/codegen/reserved-keywords.ts
+++ b/packages/target-ethers-v5/src/codegen/reserved-keywords.ts
@@ -1,0 +1,1 @@
+export const reservedKeywords = new Set(['signer', 'provider', 'deployTransaction', 'deployed', 'fallback', 'connect'])

--- a/packages/target-truffle-v4-test/types/truffle-contracts/NAME12mangling.d.ts
+++ b/packages/target-truffle-v4-test/types/truffle-contracts/NAME12mangling.d.ts
@@ -13,4 +13,6 @@ type AllEvents = never;
 
 export interface NAME12manglingInstance extends Truffle.ContractInstance {
   works(txDetails?: Truffle.TransactionDetails): Promise<boolean>;
+
+  provider(txDetails?: Truffle.TransactionDetails): Promise<boolean>;
 }

--- a/packages/target-truffle-v5-test/types/truffle-contracts/NAME12mangling.d.ts
+++ b/packages/target-truffle-v5-test/types/truffle-contracts/NAME12mangling.d.ts
@@ -15,8 +15,12 @@ type AllEvents = never;
 export interface NAME12manglingInstance extends Truffle.ContractInstance {
   works(txDetails?: Truffle.TransactionDetails): Promise<boolean>;
 
+  provider(txDetails?: Truffle.TransactionDetails): Promise<boolean>;
+
   methods: {
     works(txDetails?: Truffle.TransactionDetails): Promise<boolean>;
+
+    provider(txDetails?: Truffle.TransactionDetails): Promise<boolean>;
   };
 
   getPastEvents(event: string): Promise<EventData[]>;

--- a/packages/target-web3-v1-test/types/Name-Mangling.d.ts
+++ b/packages/target-web3-v1-test/types/Name-Mangling.d.ts
@@ -29,6 +29,8 @@ export interface NameMangling extends BaseContract {
   ): NameMangling;
   clone(): NameMangling;
   methods: {
+    provider(): NonPayableTransactionObject<boolean>;
+
     works(): NonPayableTransactionObject<boolean>;
   };
   events: {


### PR DESCRIPTION
Closes: https://github.com/ethereum-ts/TypeChain/issues/298