### PR TITLE
[web3] accept BN as input for numbers

### DIFF
--- a/.changeset/shaggy-schools-poke.md
+++ b/.changeset/shaggy-schools-poke.md
@@ -1,0 +1,5 @@
+---
+'@typechain/web3-v1': minor
+---
+
+[web3] accept BN as input for numbers

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea/
 node_modules
 dist
 .nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 node_modules
 dist
 .nyc_output

--- a/packages/target-web3-v1-test/test/DataTypesInput.test.ts
+++ b/packages/target-web3-v1-test/test/DataTypesInput.test.ts
@@ -3,6 +3,7 @@ import { typedAssert, q18 } from 'test-utils'
 
 import { createNewBlockchain, deployContract } from './common'
 import { DataTypesInput } from '../types/DataTypesInput'
+import BN from 'bn.js'
 
 describe('DataTypesInput', () => {
   let contract!: DataTypesInput
@@ -13,18 +14,24 @@ describe('DataTypesInput', () => {
     contract = await deployContract<DataTypesInput>(web3, accounts, 'DataTypesInput')
   })
 
+  const bn = (s: string) => new BN(s)
+
   it('works', async () => {
     typedAssert(await contract.methods.input_uint8('42').call(), '42')
     typedAssert(await contract.methods.input_uint8(42).call(), '42')
+    typedAssert(await contract.methods.input_uint8(bn('42')).call(), '42')
 
     typedAssert(await contract.methods.input_uint256(q18(1)).call(), q18(1))
     typedAssert(await contract.methods.input_uint256(1).call(), '1')
+    typedAssert(await contract.methods.input_uint256(bn(q18(1))).call(), q18(1))
 
     typedAssert(await contract.methods.input_int8('42').call(), '42')
     typedAssert(await contract.methods.input_int8(42).call(), '42')
+    typedAssert(await contract.methods.input_int8(bn('42')).call(), '42')
 
     typedAssert(await contract.methods.input_int256(q18(1)).call(), q18(1))
     typedAssert(await contract.methods.input_int256(1).call(), '1')
+    typedAssert(await contract.methods.input_int256(bn(q18(1))).call(), q18(1))
 
     typedAssert(await contract.methods.input_bool(true).call(), true)
 
@@ -42,14 +49,23 @@ describe('DataTypesInput', () => {
 
     typedAssert(await contract.methods.input_stat_array(['1', '2', '3']).call(), ['1', '2', '3'])
     typedAssert(await contract.methods.input_stat_array([1, 2, 3]).call(), ['1', '2', '3'])
+    // TODO this fails due to an issue in web3 abi coder handling of inner BN:
+    // typedAssert(
+    //   await contract.methods.input_stat_array([bn('1'), bn('2'), bn('3')]).call(),
+    //   ['1', '2', '3'],
+    // )
 
     typedAssert(await contract.methods.input_tuple('1', '2').call(), { 0: '1', 1: '2' })
     typedAssert(await contract.methods.input_tuple(1, 2).call(), { 0: '1', 1: '2' })
+    typedAssert(await contract.methods.input_tuple(bn('1'), bn('2')).call(), { 0: '1', 1: '2' })
 
     typedAssert(await contract.methods.input_struct(['1', '2']).call(), ['1', '2'])
     typedAssert(await contract.methods.input_struct([1, 2]).call(), ['1', '2'])
+    // TODO this fails without the .toString() due to an issue in web3 abi coder handling of inner BN:
+    // typedAssert(await contract.methods.input_struct([bn('1'), bn('2')]).call(), ['1', '2'])
 
     typedAssert(await contract.methods.input_enum('1').call(), '1')
     typedAssert(await contract.methods.input_enum(1).call(), '1')
+    typedAssert(await contract.methods.input_enum(bn('1')).call(), '1')
   })
 })

--- a/packages/target-web3-v1-test/test/DataTypesInput.test.ts
+++ b/packages/target-web3-v1-test/test/DataTypesInput.test.ts
@@ -61,7 +61,7 @@ describe('DataTypesInput', () => {
 
     typedAssert(await contract.methods.input_struct(['1', '2']).call(), ['1', '2'])
     typedAssert(await contract.methods.input_struct([1, 2]).call(), ['1', '2'])
-    // TODO this fails without the .toString() due to an issue in web3 abi coder handling of inner BN:
+    // TODO this fails due to an issue in web3 abi coder handling of inner BN:
     // typedAssert(await contract.methods.input_struct([bn('1'), bn('2')]).call(), ['1', '2'])
 
     typedAssert(await contract.methods.input_enum('1').call(), '1')

--- a/packages/target-web3-v1-test/test/DataTypesInput.test.ts
+++ b/packages/target-web3-v1-test/test/DataTypesInput.test.ts
@@ -49,7 +49,8 @@ describe('DataTypesInput', () => {
 
     typedAssert(await contract.methods.input_stat_array(['1', '2', '3']).call(), ['1', '2', '3'])
     typedAssert(await contract.methods.input_stat_array([1, 2, 3]).call(), ['1', '2', '3'])
-    // TODO this fails due to an issue in web3 abi coder handling of inner BN:
+
+    // TODO this fails due to an issue in web3 abi coder handling of inner BN (see https://github.com/ChainSafe/web3.js/issues/3920)
     // typedAssert(
     //   await contract.methods.input_stat_array([bn('1'), bn('2'), bn('3')]).call(),
     //   ['1', '2', '3'],
@@ -61,7 +62,8 @@ describe('DataTypesInput', () => {
 
     typedAssert(await contract.methods.input_struct(['1', '2']).call(), ['1', '2'])
     typedAssert(await contract.methods.input_struct([1, 2]).call(), ['1', '2'])
-    // TODO this fails due to an issue in web3 abi coder handling of inner BN:
+
+    // TODO this fails due to an issue in web3 abi coder handling of inner BN (see https://github.com/ChainSafe/web3.js/issues/3920)
     // typedAssert(await contract.methods.input_struct([bn('1'), bn('2')]).call(), ['1', '2'])
 
     typedAssert(await contract.methods.input_enum('1').call(), '1')

--- a/packages/target-web3-v1-test/types/DataTypesInput.d.ts
+++ b/packages/target-web3-v1-test/types/DataTypesInput.d.ts
@@ -39,33 +39,43 @@ export interface DataTypesInput extends BaseContract {
       input1: string | number[]
     ): NonPayableTransactionObject<string>;
 
-    input_enum(input1: number | string): NonPayableTransactionObject<string>;
+    input_enum(
+      input1: number | string | BN
+    ): NonPayableTransactionObject<string>;
 
-    input_int256(input1: number | string): NonPayableTransactionObject<string>;
+    input_int256(
+      input1: number | string | BN
+    ): NonPayableTransactionObject<string>;
 
-    input_int8(input1: number | string): NonPayableTransactionObject<string>;
+    input_int8(
+      input1: number | string | BN
+    ): NonPayableTransactionObject<string>;
 
     input_stat_array(
-      input1: (number | string)[]
+      input1: (number | string | BN)[]
     ): NonPayableTransactionObject<string[]>;
 
     input_string(input1: string): NonPayableTransactionObject<string>;
 
     input_struct(
-      input1: [number | string, number | string]
+      input1: [number | string | BN, number | string | BN]
     ): NonPayableTransactionObject<[string, string]>;
 
     input_tuple(
-      input1: number | string,
-      input2: number | string
+      input1: number | string | BN,
+      input2: number | string | BN
     ): NonPayableTransactionObject<{
       0: string;
       1: string;
     }>;
 
-    input_uint256(input1: number | string): NonPayableTransactionObject<string>;
+    input_uint256(
+      input1: number | string | BN
+    ): NonPayableTransactionObject<string>;
 
-    input_uint8(input1: number | string): NonPayableTransactionObject<string>;
+    input_uint8(
+      input1: number | string | BN
+    ): NonPayableTransactionObject<string>;
   };
   events: {
     allEvents(options?: EventOptions, cb?: Callback<EventLog>): EventEmitter;

--- a/packages/target-web3-v1-test/types/Library.d.ts
+++ b/packages/target-web3-v1-test/types/Library.d.ts
@@ -29,7 +29,7 @@ export interface Library extends BaseContract {
   ): Library;
   clone(): Library;
   methods: {
-    other(b: number | string): NonPayableTransactionObject<string>;
+    other(b: number | string | BN): NonPayableTransactionObject<string>;
   };
   events: {
     allEvents(options?: EventOptions, cb?: Callback<EventLog>): EventEmitter;

--- a/packages/target-web3-v1-test/types/LibraryConsumer.d.ts
+++ b/packages/target-web3-v1-test/types/LibraryConsumer.d.ts
@@ -29,7 +29,7 @@ export interface LibraryConsumer extends BaseContract {
   ): LibraryConsumer;
   clone(): LibraryConsumer;
   methods: {
-    someOther(b: number | string): NonPayableTransactionObject<string>;
+    someOther(b: number | string | BN): NonPayableTransactionObject<string>;
   };
   events: {
     allEvents(options?: EventOptions, cb?: Callback<EventLog>): EventEmitter;

--- a/packages/target-web3-v1-test/types/Overloads.d.ts
+++ b/packages/target-web3-v1-test/types/Overloads.d.ts
@@ -30,12 +30,12 @@ export interface Overloads extends BaseContract {
   clone(): Overloads;
   methods: {
     "overload1(int256)"(
-      input1: number | string
+      input1: number | string | BN
     ): NonPayableTransactionObject<string>;
 
     "overload1(uint256,uint256)"(
-      input1: number | string,
-      input2: number | string
+      input1: number | string | BN,
+      input2: number | string | BN
     ): NonPayableTransactionObject<string>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/types.d.ts
+++ b/packages/target-web3-v1-test/types/types.d.ts
@@ -32,17 +32,17 @@ export interface ContractEventEmitter<T> extends EventEmitter {
 }
 
 export interface NonPayableTx {
-  nonce?: string | number;
-  chainId?: string | number;
+  nonce?: string | number | BN;
+  chainId?: string | number | BN;
   from?: string;
   to?: string;
   data?: string;
-  gas?: string | number;
-  gasPrice?: string | number;
+  gas?: string | number | BN;
+  gasPrice?: string | number | BN;
 }
 
 export interface PayableTx extends NonPayableTx {
-  value?: string | number;
+  value?: string | number | BN;
 }
 
 export interface NonPayableTransactionObject<T> {

--- a/packages/target-web3-v1/src/codegen/types.ts
+++ b/packages/target-web3-v1/src/codegen/types.ts
@@ -24,7 +24,7 @@ export function codegenInputType(evmType: EvmType): string {
   switch (evmType.type) {
     case 'integer':
     case 'uinteger':
-      return 'number | string'
+      return 'number | string | BN'
     case 'address':
       return 'string'
     case 'bytes':

--- a/packages/target-web3-v1/static/types.d.ts
+++ b/packages/target-web3-v1/static/types.d.ts
@@ -26,17 +26,17 @@ export interface ContractEventEmitter<T> extends EventEmitter {
 }
 
 export interface NonPayableTx {
-  nonce?: string | number
-  chainId?: string | number
+  nonce?: string | number | BN
+  chainId?: string | number | BN
   from?: string
   to?: string
   data?: string
-  gas?: string | number
-  gasPrice?: string | number
+  gas?: string | number | BN
+  gasPrice?: string | number | BN
 }
 
 export interface PayableTx extends NonPayableTx {
-  value?: string | number
+  value?: string | number | BN
 }
 
 export interface NonPayableTransactionObject<T> {


### PR DESCRIPTION
web3 can handle BN values for number inputs.

This PR adds ` | BN` to all number inputs, making working with web3 + TypeScript easier.
Instead of `contract.methods.foo(bn.toString())`
we can now just `contract.methods.foo(bn)`.

There is a runtime error when passing BN as properties of structs or arrays:
```
     Error: invalid number value (arg="input1", coderType="uint8", value="1")
      at Object.throwError (/TypeChain/node_modules/ethers/utils/errors.js:68:17)
      at CoderNumber.encode (/TypeChain/node_modules/ethers/utils/abi-coder.js:353:20)
      at /TypeChain/node_modules/ethers/utils/abi-coder.js:605:59
      at Array.forEach (<anonymous>)
...
```
This appears to be a bug in `web3-eth-contract`'s `abi-coder`, which under the hood, [uses `ethers`'s `abi-coder`](https://github.com/ChainSafe/web3.js/blob/1.x/packages/web3-eth-abi/src/index.js#L28) (wut 😆 ),
IMHO can be ignored here, as its not under this repo's responsibility.

see similar issue https://github.com/ChainSafe/web3.js/issues/3795