### PR TITLE
[ethers-v5] Make filter parameters optional

### DIFF
--- a/packages/target-ethers-v5-test/test/Events.test.ts
+++ b/packages/target-ethers-v5-test/test/Events.test.ts
@@ -32,6 +32,19 @@ describe('Events', () => {
     })
   })
 
+  it('queryFilter without params', async () => {
+    await contract.emit_event1()
+
+    const filter = contract.filters.Event1()
+    const results = await contract.queryFilter(filter)
+    results.map((r) => {
+      typedAssert(r.args.value1, BigNumber.from(1))
+      typedAssert(r.args.value2, BigNumber.from(2))
+      typedAssert(r.args[0], BigNumber.from(1))
+      typedAssert(r.args[1], BigNumber.from(2))
+    })
+  })
+
   it('contract.on', async () => {
     const filter = contract.filters.Event1(null, null)
     const results = await contract.queryFilter(filter)

--- a/packages/target-ethers-v5-test/types/Events.d.ts
+++ b/packages/target-ethers-v5-test/types/Events.d.ts
@@ -202,29 +202,31 @@ export class Events extends BaseContract {
 
   filters: {
     AnonEvent1(
-      value1: BigNumberish | null
+      value1?: BigNumberish | null
     ): TypedEventFilter<[BigNumber], { value1: BigNumber }>;
 
     Event1(
-      value1: BigNumberish | null,
-      value2: null
+      value1?: BigNumberish | null,
+      value2?: null
     ): TypedEventFilter<
       [BigNumber, BigNumber],
       { value1: BigNumber; value2: BigNumber }
     >;
 
-    Event2(undefined: null): TypedEventFilter<[BigNumber], { arg0: BigNumber }>;
+    Event2(
+      undefined?: null
+    ): TypedEventFilter<[BigNumber], { arg0: BigNumber }>;
 
     Event3(
-      value1: boolean | null,
-      value2: null
+      value1?: boolean | null,
+      value2?: null
     ): TypedEventFilter<
       [boolean, BigNumber],
       { value1: boolean; value2: BigNumber }
     >;
 
     Event4(
-      data: null
+      data?: null
     ): TypedEventFilter<
       [[BigNumber, string] & { index: BigNumber; name: string }],
       { data: [BigNumber, string] & { index: BigNumber; name: string } }

--- a/packages/target-ethers-v5/src/codegen/index.ts
+++ b/packages/target-ethers-v5/src/codegen/index.ts
@@ -324,7 +324,7 @@ function generateEventTypes(eventArgs: EventArgDeclaration[]) {
   return (
     eventArgs
       .map((arg) => {
-        return `${arg.name}: ${generateEventArgType(arg)}`
+        return `${arg.name}?: ${generateEventArgType(arg)}`
       })
       .join(', ') + ', '
   )


### PR DESCRIPTION
#379

Before:

```ts
Transfer(
  from: string | null,
  to: string | null,
  value: null
): TypedEventFilter<
  [string, string, BigNumber],
  { from: string; to: string; amount: BigNumber; }
>;

// for all erc20 transfers
const filter = contract.filters.Transfer(null, null, null)
```

After

```ts
Transfer(
  from?: string | null,
  to?: string | null,
  value?: null
): TypedEventFilter<
  [string, string, BigNumber],
  { from: string; to: string; amount: BigNumber; }
>;

// for all erc20 transfers
const filter = contract.filters.Transfer()

// for all erc20 transfers from a given address 0x1234...
const filter = contract.filters.Transfer('0x1234...')

// for all erc20 transfers to a given address 0x1234...
const filter = contract.filters.Transfer(null, '0x1234...')
```