### PR TITLE
feat: define TASK_TYPECHAIN constant

### DIFF
--- a/packages/hardhat/src/constants.ts
+++ b/packages/hardhat/src/constants.ts
@@ -1,0 +1,1 @@
+export const TASK_TYPECHAIN: string = 'typechain'

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -1,5 +1,4 @@
 import fsExtra from 'fs-extra'
-import _, { flatten, uniq } from 'lodash'
 import { TASK_CLEAN, TASK_COMPILE, TASK_COMPILE_SOLIDITY_COMPILE_JOBS } from 'hardhat/builtin-tasks/task-names'
 import { extendConfig, task, subtask } from 'hardhat/config'
 import { HardhatPluginError } from 'hardhat/plugins'
@@ -7,7 +6,7 @@ import { getFullyQualifiedName } from 'hardhat/utils/contract-names'
 import { runTypeChain, glob } from 'typechain'
 
 import { getDefaultTypechainConfig } from './config'
-import './type-extensions'
+import { TASK_TYPECHAIN } from './constants'
 
 const taskArgsStore: { noTypechain: boolean; fullRebuild: boolean } = { noTypechain: false, fullRebuild: false }
 
@@ -87,7 +86,7 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOBS, 'Compiles the entire project, buildi
   },
 )
 
-task('typechain', 'Generate Typechain typings for compiled contracts').setAction(async (_, { run }) => {
+task(TASK_TYPECHAIN, 'Generate Typechain typings for compiled contracts').setAction(async (_, { run }) => {
   taskArgsStore.fullRebuild = true
   await run(TASK_COMPILE, { quiet: true })
 })


### PR DESCRIPTION
I'm building a plugin that depends on `@typechain/hardhat`, and I'd like to be able to import the name of the TypeChain task from the package. Currently the "typechain" task is named via a constant literal.

Besides this being useful for my own purposes, defining task names as constants in a `constants.ts` file seems to be the standard used by Hardhat in their native plugins:

https://github.com/nomiclabs/hardhat/blob/88ab5f0b7bdcffe8627f86e020846f056be3bf20/packages/hardhat-etherscan/src/constants.ts