### PR TITLE
Import type-extensions in Hardhat plugin index

### DIFF
--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -1,13 +1,13 @@
 import fsExtra from 'fs-extra'
 import { TASK_CLEAN, TASK_COMPILE, TASK_COMPILE_SOLIDITY_COMPILE_JOBS } from 'hardhat/builtin-tasks/task-names'
 import { extendConfig, task, subtask } from 'hardhat/config'
-import { HardhatPluginError } from 'hardhat/plugins'
 import { getFullyQualifiedName } from 'hardhat/utils/contract-names'
 import _, { uniq } from 'lodash'
 import { runTypeChain, glob } from 'typechain'
 
 import { getDefaultTypechainConfig } from './config'
 import { TASK_TYPECHAIN } from './constants'
+import './type-extensions';
 
 const taskArgsStore: { noTypechain: boolean; fullRebuild: boolean } = { noTypechain: false, fullRebuild: false }
 

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -7,7 +7,7 @@ import { runTypeChain, glob } from 'typechain'
 
 import { getDefaultTypechainConfig } from './config'
 import { TASK_TYPECHAIN } from './constants'
-import './type-extensions';
+import './type-extensions'
 
 const taskArgsStore: { noTypechain: boolean; fullRebuild: boolean } = { noTypechain: false, fullRebuild: false }
 


### PR DESCRIPTION
This at least partially fixes the issue described in #420. The `HardhatPluginError` import was unused so I removed that, and added the `./type-extensions` import to make sure it's included in the resulting `index.d.ts`.