### PR TITLE
Move Hardhat type generation to subtask

### DIFF
--- a/.changeset/stupid-eggs-hunt.md
+++ b/.changeset/stupid-eggs-hunt.md
@@ -1,0 +1,5 @@
+---
+'@typechain/hardhat': minor
+---
+
+Move type generation to Hardhat subtask for easier third-party integration

--- a/packages/hardhat/src/constants.ts
+++ b/packages/hardhat/src/constants.ts
@@ -1,2 +1,2 @@
 export const TASK_TYPECHAIN: string = 'typechain'
-export const TASK_TYPECHAIN_INTERNAL: string = 'typechain-internal'
+export const TASK_TYPECHAIN_GENERATE_TYPES: string = 'typechain-generate-types'

--- a/packages/hardhat/src/constants.ts
+++ b/packages/hardhat/src/constants.ts
@@ -1,1 +1,2 @@
 export const TASK_TYPECHAIN: string = 'typechain'
+export const TASK_TYPECHAIN_INTERNAL: string = 'typechain-internal'

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -91,8 +91,7 @@ subtask(TASK_TYPECHAIN_GENERATE_TYPES)
       })
       console.log(`Successfully generated ${result.filesGenerated} typings for external artifacts!`)
     }
-  }
-)
+  })
 
 task(TASK_TYPECHAIN, 'Generate Typechain typings for compiled contracts').setAction(async (_, { run }) => {
   taskArgsStore.fullRebuild = true

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -2,13 +2,13 @@ import './type-extensions'
 
 import fsExtra from 'fs-extra'
 import { TASK_CLEAN, TASK_COMPILE, TASK_COMPILE_SOLIDITY_COMPILE_JOBS } from 'hardhat/builtin-tasks/task-names'
-import { extendConfig, subtask, task } from 'hardhat/config'
+import { extendConfig, subtask, task, types } from 'hardhat/config'
 import { getFullyQualifiedName } from 'hardhat/utils/contract-names'
 import _, { uniq } from 'lodash'
 import { glob, runTypeChain } from 'typechain'
 
 import { getDefaultTypechainConfig } from './config'
-import { TASK_TYPECHAIN } from './constants'
+import { TASK_TYPECHAIN, TASK_TYPECHAIN_INTERNAL } from './constants'
 
 const taskArgsStore: { noTypechain: boolean; fullRebuild: boolean } = { noTypechain: false, fullRebuild: false }
 
@@ -26,9 +26,16 @@ task(TASK_COMPILE, 'Compiles the entire project, building all artifacts')
   })
 
 subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOBS, 'Compiles the entire project, building all artifacts').setAction(
-  async (taskArgs, { config, artifacts }, runSuper) => {
+  async (taskArgs, { config, artifacts, run }, runSuper) => {
     const compileSolOutput = await runSuper(taskArgs)
+    await run(TASK_TYPECHAIN_INTERNAL, { compileSolOutput })
+    return compileSolOutput
+  },
+)
 
+subtask(TASK_TYPECHAIN_INTERNAL)
+  .addParam('compileSolOutput', 'Solidity compilation output', {}, types.any)
+  .setAction(async ({ compileSolOutput }, { config, artifacts }) => {
     const artifactFQNs: string[] = getFQNamesFromCompilationOutput(compileSolOutput)
     const artifactPaths = uniq(
       artifactFQNs.map((fqn) => (artifacts as any)._getArtifactPathFromFullyQualifiedName(fqn)),
@@ -84,9 +91,7 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOBS, 'Compiles the entire project, buildi
       })
       console.log(`Successfully generated ${result.filesGenerated} typings for external artifacts!`)
     }
-
-    return compileSolOutput
-  },
+  }
 )
 
 task(TASK_TYPECHAIN, 'Generate Typechain typings for compiled contracts').setAction(async (_, { run }) => {

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -26,7 +26,7 @@ task(TASK_COMPILE, 'Compiles the entire project, building all artifacts')
   })
 
 subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOBS, 'Compiles the entire project, building all artifacts').setAction(
-  async (taskArgs, { config, artifacts, run }, runSuper) => {
+  async (taskArgs, { run }, runSuper) => {
     const compileSolOutput = await runSuper(taskArgs)
     await run(TASK_TYPECHAIN_GENERATE_TYPES, { compileSolOutput })
     return compileSolOutput

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -8,7 +8,7 @@ import _, { uniq } from 'lodash'
 import { glob, runTypeChain } from 'typechain'
 
 import { getDefaultTypechainConfig } from './config'
-import { TASK_TYPECHAIN, TASK_TYPECHAIN_INTERNAL } from './constants'
+import { TASK_TYPECHAIN, TASK_TYPECHAIN_GENERATE_TYPES } from './constants'
 
 const taskArgsStore: { noTypechain: boolean; fullRebuild: boolean } = { noTypechain: false, fullRebuild: false }
 
@@ -28,12 +28,12 @@ task(TASK_COMPILE, 'Compiles the entire project, building all artifacts')
 subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOBS, 'Compiles the entire project, building all artifacts').setAction(
   async (taskArgs, { config, artifacts, run }, runSuper) => {
     const compileSolOutput = await runSuper(taskArgs)
-    await run(TASK_TYPECHAIN_INTERNAL, { compileSolOutput })
+    await run(TASK_TYPECHAIN_GENERATE_TYPES, { compileSolOutput })
     return compileSolOutput
   },
 )
 
-subtask(TASK_TYPECHAIN_INTERNAL)
+subtask(TASK_TYPECHAIN_GENERATE_TYPES)
   .addParam('compileSolOutput', 'Solidity compilation output', {}, types.any)
   .setAction(async ({ compileSolOutput }, { config, artifacts }) => {
     const artifactFQNs: string[] = getFQNamesFromCompilationOutput(compileSolOutput)


### PR DESCRIPTION
Using a subtask affords more flexibility to plugin developers and end users who wish to integrate with Typechain.  I have a case where bytecode needs to be modified after compilation, but before types are generated, and currently the only means of doing this relies on importing tasks in a particular order, which is not intuitive.