### PR TITLE
docs: add @paulrberg's solidity-template example

### DIFF
--- a/packages/hardhat/README.md
+++ b/packages/hardhat/README.md
@@ -162,5 +162,6 @@ describe('Counter', () => {
 - [starter kit](https://github.com/rhlsthrm/typescript-solidity-dev-starter-kit)
 - [example-ethers](https://github.com/ethereum-ts/TypeChain/tree/master/examples/hardhat)
 - [example-truffle](https://github.com/ethereum-ts/TypeChain/tree/master/examples/hardhat-truffle-v5)
+- @paulrberg's [solidity-template](https://github.com/paulrberg/solidity-template)
 
 Original work done by [@RHLSTHRM](https://twitter.com/RHLSTHRM).


### PR DESCRIPTION
One of the main attractions of my [solidity-template](https://github.com/paulrberg/solidity-template) is the off-the-shelf integration of TypeChain, and of this Hardhat plugin.