### PR TITLE
Sync hardhat's peer dependency to latest typechain

### DIFF
--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "hardhat": "^2.0.10",
-    "typechain": "^5.0.0",
+    "typechain": "^5.1.2",
     "lodash": "^4.17.15"
   }
 }


### PR DESCRIPTION
See https://github.com/nomiclabs/hardhat/issues/1672, specifically https://github.com/nomiclabs/hardhat/issues/1672#issuecomment-894497156

See also https://github.com/sc-forks/solidity-coverage/issues/644