### PR TITLE
Remove duplicate devDependency on @types/prettier

### DIFF
--- a/packages/typechain/package.json
+++ b/packages/typechain/package.json
@@ -51,7 +51,6 @@
     "@types/lodash": "^4.14.139",
     "@types/mkdirp": "^1.0.1",
     "@types/node": "^8.0.25",
-    "@types/prettier": "^1.13.2",
     "bluebird": "^3.5.1",
     "coveralls": "^3.0.2"
   },


### PR DESCRIPTION
There is already `"@types/prettier": "^2.1.1",` in `"dependencies"`.