### PR TITLE
Add warning comment to _npx_ call -- might help other contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "eslint-plugin-unused-imports": "^1.1.1",
     "mocha": "^8.2.0",
     "prettier": "^2.1.2",
-    "solc": "^0.6.4",
     "ts-node": "^8.5.4",
     "typescript": "4.1.5",
     "wsrun": "^5.2.4"

--- a/scripts/compile-contracts.ts
+++ b/scripts/compile-contracts.ts
@@ -65,7 +65,8 @@ function generateABIs({ rootDir, contracts }: Files) {
 
     console.log(bold(`Compiling ${fileNames.length} contracts with \`npx solc@${semver}\``))
 
-    // BEWARE: This may be broken on NPM 7 — https://github.com/npm/cli/issues/3210
+    // BEWARE: Do not install solc to devDependencies until the following NPM 7
+    // issue is fixed: https://github.com/npm/cli/issues/3210
     execSync(`npx solc@${semver} --abi ${contractPaths} --bin -o ./contracts/compiled/${dirName}`, {
       cwd: rootDir,
       stdio: ['ignore', 'ignore', 'inherit'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -14787,20 +14787,6 @@ solc@^0.4.20:
     semver "^5.3.0"
     yargs "^4.7.1"
 
-solc@^0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.6.4.tgz#4b0f11fccd6f5ef9802c6bb1c007abb16881c2ca"
-  integrity sha512-HjUCys7ue9n7lGCa1XNf+wDdEY/wY64CpwnD4iPxW+BYYUX6ytwWXKitoolPXOOVxq4jewvwtL7Pngs+5k954A==
-  dependencies:
-    command-exists "^1.2.8"
-    commander "3.0.2"
-    fs-extra "^0.30.0"
-    js-sha3 "0.8.0"
-    memorystream "^0.3.1"
-    require-from-string "^2.0.0"
-    semver "^5.5.0"
-    tmp "0.0.33"
-
 solidity-comments-extractor@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"


### PR DESCRIPTION
npx in NPM 7 prefers local package to the version you explicitly request :/

See https://github.com/npm/cli/issues/3210