### PR TITLE
Use `status --verbose` instead of diff `--no-pager` in `no-git-changes.sh`

### DIFF
--- a/scripts/no-git-changes.sh
+++ b/scripts/no-git-changes.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 if [[ `git status --porcelain` ]]; then
   echo "GIT changes detected! Run yarn test:fix and commit and changes (especially in test fixtures)."
 
-  git --no-pager diff
+  git status --verbose --verbose
 
   exit 1
 fi


### PR DESCRIPTION
### Before

![image](https://user-images.githubusercontent.com/15332326/137128014-d0983159-38e2-41c5-bf81-d9b0095b56f1.png)

It seems that `git --no-pager diff` doesn't display on CI when new files are added.

### After

`git status --verbose --verbose` should display both new files and changes.

![image](https://user-images.githubusercontent.com/15332326/137128332-aedf3e49-c6ae-471f-93b7-722e215e00e9.png)
