### PR TITLE
Bump peer dependencies also when they're in range.

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,8 +6,5 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "minor",
-  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "onlyUpdatePeerDependentsWhenOutOfRange": true
-  },
   "ignore": []
 }


### PR DESCRIPTION
It seems this flag is the culprit of our latest CI issues.

See
- https://github.com/atlassian/changesets/pull/383
- https://github.com/atlassian/changesets/issues/524
