### PR TITLE
Set signerOrProvider optional

### DIFF
--- a/packages/hardhat-test/typechain-types/factories/Counter__factory.ts
+++ b/packages/hardhat-test/typechain-types/factories/Counter__factory.ts
@@ -105,7 +105,7 @@ export class Counter__factory extends ContractFactory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): Counter {
     return new Contract(address, _abi, signerOrProvider) as Counter;
   }

--- a/packages/hardhat-test/typechain-types/factories/Demo__factory.ts
+++ b/packages/hardhat-test/typechain-types/factories/Demo__factory.ts
@@ -95,7 +95,7 @@ export class Demo__factory extends ContractFactory {
   static createInterface(): DemoInterface {
     return new utils.Interface(_abi) as DemoInterface;
   }
-  static connect(address: string, signerOrProvider: Signer | Provider): Demo {
+  static connect(address: string, signerOrProvider?: Signer | Provider): Demo {
     return new Contract(address, _abi, signerOrProvider) as Demo;
   }
 }

--- a/packages/hardhat-test/typechain-types/factories/Directory/Hello__factory.ts
+++ b/packages/hardhat-test/typechain-types/factories/Directory/Hello__factory.ts
@@ -71,7 +71,7 @@ export class Hello__factory extends ContractFactory {
   static createInterface(): HelloInterface {
     return new utils.Interface(_abi) as HelloInterface;
   }
-  static connect(address: string, signerOrProvider: Signer | Provider): Hello {
+  static connect(address: string, signerOrProvider?: Signer | Provider): Hello {
     return new Contract(address, _abi, signerOrProvider) as Hello;
   }
 }

--- a/packages/hardhat-test/typechain-types/factories/StructsInConstructor__factory.ts
+++ b/packages/hardhat-test/typechain-types/factories/StructsInConstructor__factory.ts
@@ -85,7 +85,7 @@ export class StructsInConstructor__factory extends ContractFactory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): StructsInConstructor {
     return new Contract(
       address,

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/DataTypesInput__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/DataTypesInput__factory.ts
@@ -959,7 +959,7 @@ export class DataTypesInput__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): DataTypesInput {
     return new Contract(address, _abi, signerOrProvider) as DataTypesInput;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/DataTypesPure__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/DataTypesPure__factory.ts
@@ -223,7 +223,7 @@ export class DataTypesPure__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): DataTypesPure {
     return new Contract(address, _abi, signerOrProvider) as DataTypesPure;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/DataTypesView__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/DataTypesView__factory.ts
@@ -223,7 +223,7 @@ export class DataTypesView__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): DataTypesView {
     return new Contract(address, _abi, signerOrProvider) as DataTypesView;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/Events__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/Events__factory.ts
@@ -183,7 +183,7 @@ export class Events__factory {
   static createInterface(): EventsInterface {
     return new utils.Interface(_abi) as EventsInterface;
   }
-  static connect(address: string, signerOrProvider: Signer | Provider): Events {
+  static connect(address: string, signerOrProvider?: Signer | Provider): Events {
     return new Contract(address, _abi, signerOrProvider) as Events;
   }
 }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/Issue428_Reproduction/A__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/Issue428_Reproduction/A__factory.ts
@@ -27,7 +27,7 @@ export class A__factory {
   static createInterface(): AInterface {
     return new utils.Interface(_abi) as AInterface;
   }
-  static connect(address: string, signerOrProvider: Signer | Provider): A {
+  static connect(address: string, signerOrProvider?: Signer | Provider): A {
     return new Contract(address, _abi, signerOrProvider) as A;
   }
 }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/Issue428_Reproduction/B__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/Issue428_Reproduction/B__factory.ts
@@ -40,7 +40,7 @@ export class B__factory {
   static createInterface(): BInterface {
     return new utils.Interface(_abi) as BInterface;
   }
-  static connect(address: string, signerOrProvider: Signer | Provider): B {
+  static connect(address: string, signerOrProvider?: Signer | Provider): B {
     return new Contract(address, _abi, signerOrProvider) as B;
   }
 }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/Library/Lib__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/Library/Lib__factory.ts
@@ -33,7 +33,7 @@ export class Lib__factory {
   static createInterface(): LibInterface {
     return new utils.Interface(_abi) as LibInterface;
   }
-  static connect(address: string, signerOrProvider: Signer | Provider): Lib {
+  static connect(address: string, signerOrProvider?: Signer | Provider): Lib {
     return new Contract(address, _abi, signerOrProvider) as Lib;
   }
 }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/LibraryConsumer__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/LibraryConsumer__factory.ts
@@ -38,7 +38,7 @@ export class LibraryConsumer__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): LibraryConsumer {
     return new Contract(address, _abi, signerOrProvider) as LibraryConsumer;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/Name-Mangling/NAME12mangling__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/Name-Mangling/NAME12mangling__factory.ts
@@ -45,7 +45,7 @@ export class NAME12mangling__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): NAME12mangling {
     return new Contract(address, _abi, signerOrProvider) as NAME12mangling;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/Overloads__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/Overloads__factory.ts
@@ -59,7 +59,7 @@ export class Overloads__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): Overloads {
     return new Contract(address, _abi, signerOrProvider) as Overloads;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/Payable/PayableFactory__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/Payable/PayableFactory__factory.ts
@@ -32,7 +32,7 @@ export class PayableFactory__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): PayableFactory {
     return new Contract(address, _abi, signerOrProvider) as PayableFactory;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/Payable/Payable__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/Payable/Payable__factory.ts
@@ -33,7 +33,7 @@ export class Payable__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): Payable {
     return new Contract(address, _abi, signerOrProvider) as Payable;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/ISimpleToken__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/ISimpleToken__factory.ts
@@ -37,7 +37,7 @@ export class ISimpleToken__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): ISimpleToken {
     return new Contract(address, _abi, signerOrProvider) as ISimpleToken;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/Issue552_Reproduction__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/Issue552_Reproduction__factory.ts
@@ -93,7 +93,7 @@ export class Issue552_Reproduction__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): Issue552_Reproduction {
     return new Contract(
       address,

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/KingOfTheHill/KingOfTheHill__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/KingOfTheHill/KingOfTheHill__factory.ts
@@ -97,7 +97,7 @@ export class KingOfTheHill__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): KingOfTheHill {
     return new Contract(address, _abi, signerOrProvider) as KingOfTheHill;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/KingOfTheHill/Withdrawable__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/KingOfTheHill/Withdrawable__factory.ts
@@ -26,7 +26,7 @@ export class Withdrawable__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): Withdrawable {
     return new Contract(address, _abi, signerOrProvider) as Withdrawable;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/ERC721Enumerable__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/ERC721Enumerable__factory.ts
@@ -341,7 +341,7 @@ export class ERC721Enumerable__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): ERC721Enumerable {
     return new Contract(address, _abi, signerOrProvider) as ERC721Enumerable;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/ERC721__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/ERC721__factory.ts
@@ -280,7 +280,7 @@ export class ERC721__factory {
   static createInterface(): ERC721Interface {
     return new utils.Interface(_abi) as ERC721Interface;
   }
-  static connect(address: string, signerOrProvider: Signer | Provider): ERC721 {
+  static connect(address: string, signerOrProvider?: Signer | Provider): ERC721 {
     return new Contract(address, _abi, signerOrProvider) as ERC721;
   }
 }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/IERC721Enumerable__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/IERC721Enumerable__factory.ts
@@ -341,7 +341,7 @@ export class IERC721Enumerable__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): IERC721Enumerable {
     return new Contract(address, _abi, signerOrProvider) as IERC721Enumerable;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/IERC721Receiver__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/IERC721Receiver__factory.ts
@@ -53,7 +53,7 @@ export class IERC721Receiver__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): IERC721Receiver {
     return new Contract(address, _abi, signerOrProvider) as IERC721Receiver;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/IERC721__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/IERC721__factory.ts
@@ -282,7 +282,7 @@ export class IERC721__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): IERC721 {
     return new Contract(address, _abi, signerOrProvider) as IERC721;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/Rarity__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/Rarity/Rarity__factory.ts
@@ -623,7 +623,7 @@ export class Rarity__factory {
   static createInterface(): RarityInterface {
     return new utils.Interface(_abi) as RarityInterface;
   }
-  static connect(address: string, signerOrProvider: Signer | Provider): Rarity {
+  static connect(address: string, signerOrProvider?: Signer | Provider): Rarity {
     return new Contract(address, _abi, signerOrProvider) as Rarity;
   }
 }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/SimpleToken__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/SimpleToken__factory.ts
@@ -37,7 +37,7 @@ export class SimpleToken__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): SimpleToken {
     return new Contract(address, _abi, signerOrProvider) as SimpleToken;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/nested/a/NestedLibrary__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/nested/a/NestedLibrary__factory.ts
@@ -32,7 +32,7 @@ export class NestedLibrary__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): NestedLibrary {
     return new Contract(address, _abi, signerOrProvider) as NestedLibrary;
   }

--- a/packages/target-ethers-v5-test/types/factories/v0.8.9/nested/b/NestedLibrary__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.8.9/nested/b/NestedLibrary__factory.ts
@@ -32,7 +32,7 @@ export class NestedLibrary__factory {
   }
   static connect(
     address: string,
-    signerOrProvider: Signer | Provider
+    signerOrProvider?: Signer | Provider
   ): NestedLibrary {
     return new Contract(address, _abi, signerOrProvider) as NestedLibrary;
   }

--- a/packages/target-ethers-v5/src/codegen/index.ts
+++ b/packages/target-ethers-v5/src/codegen/index.ts
@@ -265,7 +265,7 @@ function codegenCommonContractFactory(contract: Contract, abi: any): { header: s
     static createInterface(): ${contract.name}Interface {
       return new utils.Interface(_abi) as ${contract.name}Interface;
     }
-    static connect(address: string, signerOrProvider: Signer | Provider): ${contract.name} {
+    static connect(address: string, signerOrProvider?: Signer | Provider): ${contract.name} {
       return new Contract(address, _abi, signerOrProvider) as ${contract.name};
     }
   `.trim()


### PR DESCRIPTION
Hi,

Here's the Contract constructor signature from ethers v5:
```typescript
constructor(addressOrName: string, contractInterface: ContractInterface, signerOrProvider?: Signer | Provider)
```

I was thus wondering why TypeChain forces `signerOrProvider` to be defined, whereas `ethers` does not (and we've got a use-case where we don't want to define a signer nor a provider)

So here's a quick PR to fix this :)