### PR TITLE
add natspec support to extractDocumentation

### DIFF
--- a/.changeset/typechain-natspec.md
+++ b/.changeset/typechain-natspec.md
@@ -1,0 +1,5 @@
+---
+'typechain': patch
+---
+
+Add support for natspec field

--- a/packages/typechain/src/parser/abiParser.ts
+++ b/packages/typechain/src/parser/abiParser.ts
@@ -441,7 +441,14 @@ export function extractDocumentation(rawContents: string): DocumentationResult |
     return undefined
   }
 
-  if (!json || (!json.devdoc && !json.userdoc)) return undefined
+  if (!json) return undefined
+
+  // Tools like brownie merge devdoc and userdoc into natspec
+  if (json.natspec) {
+    return json.natspec as DocumentationResult
+  }
+
+  if (!json.devdoc && !json.userdoc) return undefined
 
   const result: DocumentationResult = json.devdoc || {}
 

--- a/packages/typechain/test/parser/abiParser.test.ts
+++ b/packages/typechain/test/parser/abiParser.test.ts
@@ -227,6 +227,49 @@ describe('extractDocumentation', () => {
       notice: 'You can use this contract for only the most basic simulation',
     })
   })
+
+  const natspec = `{
+    "natspec": {
+      "author" : "Larry A. Gardner",
+      "details" : "All function calls are currently implemented without side effects",
+      "methods" :
+      {
+        "age(uint256)" :
+        {
+          "author" : "Mary A. Botanist",
+          "notice" : "Calculate tree age in years, rounded up, for live trees",
+          "details" : "The Alexandr N. Tetearing algorithm could increase precision",
+          "params" :
+          {
+            "rings" : "The number of rings from dendrochronological sample"
+          },
+          "return" : "age in years, rounded up for partial years"
+        }
+      },
+      "notice": "You can use this contract for only the most basic simulation",
+      "title" : "A simulator for trees"
+    }
+  }`
+
+  it('should parse natspec only', () => {
+    const doc = extractDocumentation(natspec)
+
+    expect(doc).toEqual({
+      author: 'Larry A. Gardner',
+      details: 'All function calls are currently implemented without side effects',
+      methods: {
+        'age(uint256)': {
+          author: 'Mary A. Botanist',
+          details: 'The Alexandr N. Tetearing algorithm could increase precision',
+          notice: 'Calculate tree age in years, rounded up, for live trees',
+          params: { rings: 'The number of rings from dendrochronological sample' },
+          return: 'age in years, rounded up for partial years',
+        },
+      },
+      notice: 'You can use this contract for only the most basic simulation',
+      title: 'A simulator for trees',
+    })
+  })
 })
 
 describe('extractBytecode with link references', () => {


### PR DESCRIPTION
Hello there, 

Thank you for the amazing work!

I added a case to the `extractDocumentation` function to read natspec directly, as tools like brownie merge the content themselves.


see: https://github.com/eth-brownie/brownie/blob/86258c7bdf194c800ae44e853b7c55fab60a23ce/brownie/project/compiler/utils.py#L31
see: https://github.com/eth-brownie/brownie/blob/86258c7bdf194c800ae44e853b7c55fab60a23ce/tests/project/compiler/test_natspec.py#L2

