### PR TITLE
Fix having to cast web3.eth.Contract as unknown before casting to generated type

### DIFF
--- a/.changeset/dry-melons-carry.md
+++ b/.changeset/dry-melons-carry.md
@@ -1,0 +1,5 @@
+---
+'@typechain/web3-v1': minor
+---
+
+Edit Contract interface codegen to allow casting directly from web3-v1's base Contract types

--- a/examples/web3-v1/src/index.ts
+++ b/examples/web3-v1/src/index.ts
@@ -11,7 +11,7 @@ async function main() {
   const web3 = new Web3(RPC_HOST)
   const fromWei = web3.utils.fromWei
 
-  const dai = new web3.eth.Contract(abi, DAI_ADDRESS) as any as Dai
+  const dai = new web3.eth.Contract(abi, DAI_ADDRESS) as Dai
   const balance = await dai.methods.balanceOf('0x70b144972C5Ef6CB941A5379240B74239c418CD4').call()
 
   console.log(`Our DAI balance is: ${fromWei(balance)}`)

--- a/packages/target-web3-v1-test/package.json
+++ b/packages/target-web3-v1-test/package.json
@@ -21,6 +21,7 @@
     "web3": "^1.6.0",
     "web3-eth-contract": "^1.6.0",
     "web3-core": "^1",
+    "web3-utils": "^1.6.0",
     "@types/bn.js": "^4.11.6"
   }
 }

--- a/packages/target-web3-v1-test/types/types.ts
+++ b/packages/target-web3-v1-test/types/types.ts
@@ -20,7 +20,7 @@ export interface EventOptions {
 
 export type Callback<T> = (error: Error, result: T) => void;
 export interface ContractEventLog<T> extends EventLog {
-  returnValues: T;
+  returnValues: Partial<T>;
 }
 export interface ContractEventEmitter<T> extends EventEmitter {
   on(event: "connected", listener: (subscriptionId: string) => void): this;

--- a/packages/target-web3-v1-test/types/v0.6.4/DataTypesInput.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/DataTypesInput.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface DataTypesInput extends BaseContract {
+export interface DataTypesInputConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): DataTypesInput;
+}
+
+export interface DataTypesInput extends BaseContract {
   clone(): DataTypesInput;
   methods: {
     input_address(input1: string): NonPayableTransactionObject<string>;

--- a/packages/target-web3-v1-test/types/v0.6.4/DataTypesPure.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/DataTypesPure.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface DataTypesPure extends BaseContract {
+export interface DataTypesPureConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): DataTypesPure;
+}
+
+export interface DataTypesPure extends BaseContract {
   clone(): DataTypesPure;
   methods: {
     pure_address(): NonPayableTransactionObject<string>;

--- a/packages/target-web3-v1-test/types/v0.6.4/DataTypesView.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/DataTypesView.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface DataTypesView extends BaseContract {
+export interface DataTypesViewConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): DataTypesView;
+}
+
+export interface DataTypesView extends BaseContract {
   clone(): DataTypesView;
   methods: {
     view_address(): NonPayableTransactionObject<string>;

--- a/packages/target-web3-v1-test/types/v0.6.4/Events.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Events.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -54,12 +55,15 @@ export type UpdateFrequencySet = ContractEventLog<{
   1: string[];
 }>;
 
-export interface Events extends BaseContract {
+export interface EventsConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): Events;
+}
+
+export interface Events extends BaseContract {
   clone(): Events;
   methods: {
     emit_anon1(): NonPayableTransactionObject<void>;

--- a/packages/target-web3-v1-test/types/v0.6.4/Issue428_Reproduction/A.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Issue428_Reproduction/A.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -26,12 +27,15 @@ export type Committed = ContractEventLog<{
   0: string[];
 }>;
 
-export interface A extends BaseContract {
+export interface AConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): A;
+}
+
+export interface A extends BaseContract {
   clone(): A;
   methods: {};
   events: {

--- a/packages/target-web3-v1-test/types/v0.6.4/Issue428_Reproduction/B.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Issue428_Reproduction/B.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -30,12 +31,15 @@ export type Committed_address_array = ContractEventLog<{
   0: string[];
 }>;
 
-export interface B extends BaseContract {
+export interface BConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): B;
+}
+
+export interface B extends BaseContract {
   clone(): B;
   methods: {};
   events: {

--- a/packages/target-web3-v1-test/types/v0.6.4/Library/Lib.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Library/Lib.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface Lib extends BaseContract {
+export interface LibConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): Lib;
+}
+
+export interface Lib extends BaseContract {
   clone(): Lib;
   methods: {
     other(b: number | string | BN): NonPayableTransactionObject<string>;

--- a/packages/target-web3-v1-test/types/v0.6.4/LibraryConsumer.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/LibraryConsumer.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface LibraryConsumer extends BaseContract {
+export interface LibraryConsumerConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): LibraryConsumer;
+}
+
+export interface LibraryConsumer extends BaseContract {
   clone(): LibraryConsumer;
   methods: {
     someOther(b: number | string | BN): NonPayableTransactionObject<string>;

--- a/packages/target-web3-v1-test/types/v0.6.4/Name-Mangling/NAME12mangling.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Name-Mangling/NAME12mangling.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface NAME12mangling extends BaseContract {
+export interface NAME12manglingConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): NAME12mangling;
+}
+
+export interface NAME12mangling extends BaseContract {
   clone(): NAME12mangling;
   methods: {
     provider(): NonPayableTransactionObject<boolean>;

--- a/packages/target-web3-v1-test/types/v0.6.4/Overloads.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Overloads.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface Overloads extends BaseContract {
+export interface OverloadsConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): Overloads;
+}
+
+export interface Overloads extends BaseContract {
   clone(): Overloads;
   methods: {
     "overload1(int256)"(

--- a/packages/target-web3-v1-test/types/v0.6.4/Payable/Payable.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Payable/Payable.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface Payable extends BaseContract {
+export interface PayableConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): Payable;
+}
+
+export interface Payable extends BaseContract {
   clone(): Payable;
   methods: {
     non_payable_func(): NonPayableTransactionObject<void>;

--- a/packages/target-web3-v1-test/types/v0.6.4/Payable/PayableFactory.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Payable/PayableFactory.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface PayableFactory extends BaseContract {
+export interface PayableFactoryConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): PayableFactory;
+}
+
+export interface PayableFactory extends BaseContract {
   clone(): PayableFactory;
   methods: {
     newPayable(): NonPayableTransactionObject<string>;

--- a/packages/target-web3-v1-test/types/v0.8.9/ISimpleToken.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/ISimpleToken.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface ISimpleToken extends BaseContract {
+export interface ISimpleTokenConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): ISimpleToken;
+}
+
+export interface ISimpleToken extends BaseContract {
   clone(): ISimpleToken;
   methods: {
     transfer(

--- a/packages/target-web3-v1-test/types/v0.8.9/Issue552_Reproduction.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Issue552_Reproduction.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface Issue552_Reproduction extends BaseContract {
+export interface Issue552_ReproductionConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): Issue552_Reproduction;
+}
+
+export interface Issue552_Reproduction extends BaseContract {
   clone(): Issue552_Reproduction;
   methods: {
     bars(

--- a/packages/target-web3-v1-test/types/v0.8.9/KingOfTheHill/KingOfTheHill.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/KingOfTheHill/KingOfTheHill.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -26,12 +27,15 @@ export type HighestBidIncreased = ContractEventLog<{
   0: [string, string];
 }>;
 
-export interface KingOfTheHill extends BaseContract {
+export interface KingOfTheHillConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): KingOfTheHill;
+}
+
+export interface KingOfTheHill extends BaseContract {
   clone(): KingOfTheHill;
   methods: {
     bid(): PayableTransactionObject<void>;

--- a/packages/target-web3-v1-test/types/v0.8.9/KingOfTheHill/Withdrawable.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/KingOfTheHill/Withdrawable.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface Withdrawable extends BaseContract {
+export interface WithdrawableConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): Withdrawable;
+}
+
+export interface Withdrawable extends BaseContract {
   clone(): Withdrawable;
   methods: {
     withdraw(): NonPayableTransactionObject<void>;

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/ERC721.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/ERC721.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -46,12 +47,15 @@ export type Transfer = ContractEventLog<{
   2: string;
 }>;
 
-export interface ERC721 extends BaseContract {
+export interface ERC721Constructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): ERC721;
+}
+
+export interface ERC721 extends BaseContract {
   clone(): ERC721;
   methods: {
     approve(

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/ERC721Enumerable.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/ERC721Enumerable.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -46,12 +47,15 @@ export type Transfer = ContractEventLog<{
   2: string;
 }>;
 
-export interface ERC721Enumerable extends BaseContract {
+export interface ERC721EnumerableConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): ERC721Enumerable;
+}
+
+export interface ERC721Enumerable extends BaseContract {
   clone(): ERC721Enumerable;
   methods: {
     approve(

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -46,12 +47,15 @@ export type Transfer = ContractEventLog<{
   2: string;
 }>;
 
-export interface IERC721 extends BaseContract {
+export interface IERC721Constructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): IERC721;
+}
+
+export interface IERC721 extends BaseContract {
   clone(): IERC721;
   methods: {
     approve(

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721Enumerable.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721Enumerable.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -46,12 +47,15 @@ export type Transfer = ContractEventLog<{
   2: string;
 }>;
 
-export interface IERC721Enumerable extends BaseContract {
+export interface IERC721EnumerableConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): IERC721Enumerable;
+}
+
+export interface IERC721Enumerable extends BaseContract {
   clone(): IERC721Enumerable;
   methods: {
     approve(

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721Receiver.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721Receiver.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface IERC721Receiver extends BaseContract {
+export interface IERC721ReceiverConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): IERC721Receiver;
+}
+
+export interface IERC721Receiver extends BaseContract {
   clone(): IERC721Receiver;
   methods: {
     onERC721Received(

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/Rarity.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/Rarity.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -62,12 +63,15 @@ export type summoned = ContractEventLog<{
   2: string;
 }>;
 
-export interface Rarity extends BaseContract {
+export interface RarityConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): Rarity;
+}
+
+export interface Rarity extends BaseContract {
   clone(): Rarity;
   methods: {
     adventure(

--- a/packages/target-web3-v1-test/types/v0.8.9/SimpleToken.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/SimpleToken.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface SimpleToken extends BaseContract {
+export interface SimpleTokenConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): SimpleToken;
+}
+
+export interface SimpleToken extends BaseContract {
   clone(): SimpleToken;
   methods: {
     transfer(

--- a/packages/target-web3-v1-test/types/v0.8.9/nested/a/NestedLibrary.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/nested/a/NestedLibrary.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface NestedLibrary extends BaseContract {
+export interface NestedLibraryConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): NestedLibrary;
+}
+
+export interface NestedLibrary extends BaseContract {
   clone(): NestedLibrary;
   methods: {
     getValue(): NonPayableTransactionObject<string>;

--- a/packages/target-web3-v1-test/types/v0.8.9/nested/b/NestedLibrary.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/nested/b/NestedLibrary.ts
@@ -5,6 +5,7 @@
 import type BN from "bn.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
+import type { AbiItem } from "web3-utils";
 import type { EventEmitter } from "events";
 import type {
   Callback,
@@ -21,12 +22,15 @@ export interface EventOptions {
   topics?: string[];
 }
 
-export interface NestedLibrary extends BaseContract {
+export interface NestedLibraryConstructor {
   constructor(
-    jsonInterface: any[],
+    jsonInterface: AbiItem[],
     address?: string,
     options?: ContractOptions
   ): NestedLibrary;
+}
+
+export interface NestedLibrary extends BaseContract {
   clone(): NestedLibrary;
   methods: {
     getValue(): NonPayableTransactionObject<string>;

--- a/packages/target-web3-v1/src/codegen/index.ts
+++ b/packages/target-web3-v1/src/codegen/index.ts
@@ -10,6 +10,7 @@ export function codegen(contract: Contract) {
   import type BN from "bn.js";
   import type { ContractOptions } from "web3-eth-contract";
   import type { EventLog } from "web3-core";
+  import { AbiItem } from 'web3-utils';
   import type { EventEmitter } from "events";
   import type { Callback, PayableTransactionObject, NonPayableTransactionObject, BlockType, ContractEventLog, BaseContract } from "${typesPath}";
 
@@ -21,8 +22,11 @@ export function codegen(contract: Contract) {
 
   ${codegenForEventsDeclarations(contract.events)}
 
+  export interface ${contract.name}Constructor {
+    constructor(jsonInterface: AbiItem[], address?: string, options?: ContractOptions): ${contract.name};
+  }
+
   export interface ${contract.name} extends BaseContract {
-    constructor(jsonInterface: any[], address?: string, options?: ContractOptions): ${contract.name};
     clone(): ${contract.name};
     methods: {
       ${codegenForFunctions(contract.functions)}

--- a/packages/target-web3-v1/src/codegen/index.ts
+++ b/packages/target-web3-v1/src/codegen/index.ts
@@ -10,7 +10,7 @@ export function codegen(contract: Contract) {
   import type BN from "bn.js";
   import type { ContractOptions } from "web3-eth-contract";
   import type { EventLog } from "web3-core";
-  import { AbiItem } from 'web3-utils';
+  import type { AbiItem } from 'web3-utils';
   import type { EventEmitter } from "events";
   import type { Callback, PayableTransactionObject, NonPayableTransactionObject, BlockType, ContractEventLog, BaseContract } from "${typesPath}";
 

--- a/packages/target-web3-v1/static/types.ts
+++ b/packages/target-web3-v1/static/types.ts
@@ -17,7 +17,7 @@ export interface EventOptions {
 
 export type Callback<T> = (error: Error, result: T) => void
 export interface ContractEventLog<T> extends EventLog {
-  returnValues: T
+  returnValues: Partial<T>
 }
 export interface ContractEventEmitter<T> extends EventEmitter {
   on(event: 'connected', listener: (subscriptionId: string) => void): this

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,7 @@ importers:
       web3: ^1.6.0
       web3-core: ^1
       web3-eth-contract: ^1.6.0
+      web3-utils: ^1.6.0
     devDependencies:
       '@types/bn.js': 4.11.6
       ganache: 7.0.3
@@ -460,6 +461,7 @@ importers:
       web3: 1.7.1
       web3-core: 1.7.1
       web3-eth-contract: 1.7.1
+      web3-utils: 1.7.3
 
   packages/test-e2e:
     specifiers:
@@ -846,7 +848,7 @@ packages:
       eth-ens-namehash: 2.0.8
       solc: 0.4.26
       testrpc: 0.0.1
-      web3-utils: 1.7.1
+      web3-utils: 1.7.3
     dev: true
 
   /@ensdomains/resolver/0.2.4:
@@ -889,7 +891,7 @@ packages:
     dependencies:
       '@resolver-engine/imports': 0.3.3
       '@resolver-engine/imports-fs': 0.3.3
-      '@typechain/ethers-v5': 2.0.0_typechain@3.0.0
+      '@typechain/ethers-v5': 2.0.0_g7uto4b3myu3f235xnumgfxjwq
       '@types/mkdirp': 0.5.2
       '@types/node-fetch': 2.6.1
       ethers: 5.6.0
@@ -972,7 +974,7 @@ packages:
     resolution: {integrity: sha512-vDwye5v0SVeuDky4MtKsu+ogkH2oFUV8pBKzH/eNBzT8oI91pKa8WyzDuYuxOQsgNgv5R34LfFDh2aaw3H4HbQ==}
     dependencies:
       crc-32: 1.2.1
-      ethereumjs-util: 7.1.4
+      ethereumjs-util: 7.1.5
 
   /@ethereumjs/common/2.6.4:
     resolution: {integrity: sha512-RDJh/R/EAr+B7ZRg5LfJ0BIpf/1LydFgYdvZEuTraojCbVypO2sQ+QnpP5u2wJf9DASyooKqu8O4FJEWUV6NXw==}
@@ -995,7 +997,7 @@ packages:
     resolution: {integrity: sha512-/+ZNbnJhQhXC83Xuvy6I9k4jT5sXiV0tMR9C+AzSSpcCV64+NB8dTE1m3x98RYMqb8+TLYWA+HML4F5lfXTlJw==}
     dependencies:
       '@ethereumjs/common': 2.6.2
-      ethereumjs-util: 7.1.4
+      ethereumjs-util: 7.1.5
 
   /@ethereumjs/tx/3.5.2:
     resolution: {integrity: sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw==}
@@ -2913,16 +2915,14 @@ packages:
     resolution: {integrity: sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==}
     dev: true
 
-  /@typechain/ethers-v5/2.0.0_typechain@3.0.0:
+  /@typechain/ethers-v5/2.0.0_g7uto4b3myu3f235xnumgfxjwq:
     resolution: {integrity: sha512-0xdCkyGOzdqh4h5JSf+zoWx85IusEjDcPIwNEHP8mrWSnCae4rvrqB+/gtpdNfX7zjlFlZiMeePn2r63EI3Lrw==}
     peerDependencies:
+      ethers: ^5.0.0
       typechain: ^3.0.0
     dependencies:
       ethers: 5.6.0
       typechain: 3.0.0_typescript@4.6.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
     dev: true
 
   /@types/abstract-leveldown/7.2.0:
@@ -4061,7 +4061,7 @@ packages:
     resolution: {integrity: sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==}
     deprecated: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410
     dependencies:
-      follow-redirects: 1.14.9_debug@4.3.3
+      follow-redirects: 1.14.9
     transitivePeerDependencies:
       - debug
     optional: true
@@ -4069,14 +4069,14 @@ packages:
   /axios/0.23.0:
     resolution: {integrity: sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==}
     dependencies:
-      follow-redirects: 1.14.9_debug@4.3.3
+      follow-redirects: 1.14.9
     transitivePeerDependencies:
       - debug
 
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.14.9_debug@4.3.3
+      follow-redirects: 1.14.9
     transitivePeerDependencies:
       - debug
     dev: true
@@ -4084,7 +4084,7 @@ packages:
   /axios/0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.14.9_debug@4.3.3
+      follow-redirects: 1.14.9
     transitivePeerDependencies:
       - debug
 
@@ -4771,7 +4771,7 @@ packages:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
   /bn.js/4.11.6:
-    resolution: {integrity: sha1-UzRK2xRhehP26N0s4okF0cC6MhU=}
+    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
 
   /bn.js/4.11.8:
     resolution: {integrity: sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==}
@@ -6848,7 +6848,7 @@ packages:
     dependencies:
       async: 2.6.3
       buffer-xor: 2.0.2
-      ethereumjs-util: 7.1.4
+      ethereumjs-util: 7.1.5
       miller-rabin: 4.0.1
     dev: true
 
@@ -7072,7 +7072,6 @@ packages:
       create-hash: 1.2.0
       ethereum-cryptography: 0.1.3
       rlp: 2.2.7
-    dev: true
 
   /ethereumjs-vm/2.6.0:
     resolution: {integrity: sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==}
@@ -7217,7 +7216,7 @@ packages:
       - utf-8-validate
 
   /ethjs-unit/0.1.6:
-    resolution: {integrity: sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=}
+    resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
       bn.js: 4.11.6
@@ -7650,7 +7649,7 @@ packages:
     resolution: {integrity: sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s=}
     dev: true
 
-  /follow-redirects/1.14.9_debug@4.3.3:
+  /follow-redirects/1.14.9:
     resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -7658,8 +7657,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dependencies:
-      debug: 4.3.3
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -8617,11 +8614,11 @@ packages:
       wrappy: 1.0.2
 
   /inherits/2.0.1:
-    resolution: {integrity: sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=}
+    resolution: {integrity: sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==}
     optional: true
 
   /inherits/2.0.3:
-    resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
     optional: true
 
   /inherits/2.0.4:
@@ -8989,7 +8986,7 @@ packages:
       is-extglob: 2.1.1
 
   /is-hex-prefixed/1.0.0:
-    resolution: {integrity: sha1-fY035q135dEnFIkTxXPggtd39VQ=}
+    resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
     engines: {node: '>=6.5.0', npm: '>=3'}
 
   /is-ip/2.0.0:
@@ -11114,7 +11111,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   /number-to-bn/1.7.0:
-    resolution: {integrity: sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=}
+    resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
       bn.js: 4.11.6
@@ -12374,11 +12371,11 @@ packages:
     dev: true
 
   /readable-stream/0.0.4:
-    resolution: {integrity: sha1-8y124/uGM0SlSNeZIwBxc2ZbO40=}
+    resolution: {integrity: sha512-azrivNydKRYt7zwLV5wWUK7YzKTWs3q87xSmY6DlHapPrCvaT6ZrukvM5erV+yCSSPmZT8zkSdttOHQpWWm9zw==}
     optional: true
 
   /readable-stream/1.0.33:
-    resolution: {integrity: sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=}
+    resolution: {integrity: sha512-72KxhcKi8bAvHP/cyyWSP+ODS5ef0DIRs0OzrhGXw31q41f19aoELCbvd42FjhpyEDxQMRiiC5rq9rfE5PzTqg==}
     dependencies:
       core-util-is: 1.0.3
       inherits: 2.0.4
@@ -12386,7 +12383,7 @@ packages:
       string_decoder: 0.10.31
 
   /readable-stream/1.1.14:
-    resolution: {integrity: sha1-fPTFTvZI44EwhMY23SB54WbAgdk=}
+    resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==}
     dependencies:
       core-util-is: 1.0.3
       inherits: 2.0.4
@@ -13184,7 +13181,7 @@ packages:
     dependencies:
       command-exists: 1.2.9
       commander: 3.0.2
-      follow-redirects: 1.14.9_debug@4.3.3
+      follow-redirects: 1.14.9
       fs-extra: 0.30.0
       js-sha3: 0.8.0
       memorystream: 0.3.1
@@ -13512,7 +13509,7 @@ packages:
     dev: true
 
   /strip-hex-prefix/1.0.0:
-    resolution: {integrity: sha1-DF8VX+8RUTczd96du1iNoFUA428=}
+    resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
       is-hex-prefixed: 1.0.0
@@ -14283,7 +14280,6 @@ packages:
     resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /typewise-core/1.2.0:
     resolution: {integrity: sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU=}
@@ -14625,7 +14621,7 @@ packages:
     engines: {node: '>=8.0.0'}
     requiresBuild: true
     dependencies:
-      '@types/node': 12.19.14
+      '@types/node': 12.20.52
       got: 9.6.0
       swarm-js: 0.1.40
       underscore: 1.12.1
@@ -14934,7 +14930,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       '@types/bn.js': 4.11.6
-      '@types/node': 12.19.14
+      '@types/node': 12.20.52
       bignumber.js: 9.0.2
       web3-core-helpers: 1.3.6
       web3-core-method: 1.3.6
@@ -15075,7 +15071,7 @@ packages:
       '@ethereumjs/tx': 3.5.0
       crypto-browserify: 3.12.0
       eth-lib: 0.2.8
-      ethereumjs-util: 7.1.4
+      ethereumjs-util: 7.1.5
       scrypt-js: 3.0.1
       uuid: 3.3.2
       web3-core: 1.5.3
@@ -15093,7 +15089,7 @@ packages:
       '@ethereumjs/tx': 3.5.0
       crypto-browserify: 3.12.0
       eth-lib: 0.2.8
-      ethereumjs-util: 7.1.4
+      ethereumjs-util: 7.1.5
       scrypt-js: 3.0.1
       uuid: 3.3.2
       web3-core: 1.7.1
@@ -15111,7 +15107,7 @@ packages:
       '@ethereumjs/tx': 3.5.0
       crypto-browserify: 3.12.0
       eth-lib: 0.2.8
-      ethereumjs-util: 7.1.4
+      ethereumjs-util: 7.1.5
       scrypt-js: 3.0.1
       uuid: 3.3.2
       web3-core: 1.7.3
@@ -15342,7 +15338,7 @@ packages:
     resolution: {integrity: sha512-pOHU0+/h1RFRYoh1ehYBehRbcKWP4OSzd4F7mDljhHngv6W8ewMHrAN8O1ol9uysN2MuCdRE19qkRg5eNgvzFQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/node': 12.19.14
+      '@types/node': 12.20.52
       web3-core: 1.3.6
       web3-core-helpers: 1.3.6
       web3-core-method: 1.3.6
@@ -15848,12 +15844,11 @@ packages:
     dependencies:
       bn.js: 4.12.0
       ethereum-bloom-filters: 1.0.10
-      ethereumjs-util: 7.1.4
+      ethereumjs-util: 7.1.5
       ethjs-unit: 0.1.6
       number-to-bn: 1.7.0
       randombytes: 2.1.0
       utf8: 3.0.0
-    dev: false
 
   /web3/1.2.11:
     resolution: {integrity: sha512-mjQ8HeU41G6hgOYm1pmeH0mRAeNKJGnJEUzDMoerkpw7QUQT4exVREgF1MYPvL/z6vAshOXei25LE/t/Bxl8yQ==}


### PR DESCRIPTION
Previously, when using typechain generated types, one would have to cast to `unknown` or `any` before casting to the generated Typechain type. For example:

```typescript
import { ERC20 } from '../typechain';

const contract1 = new this.web3.eth.Contract(erc20Artifact as AbiItem[], tokenAddress) as unknown as ERC20;
// or:
const contract2 = new this.web3.eth.Contract(erc20Artifact as AbiItem[], tokenAddress) as any as ERC20;
```

This is because Typescript did not consider `eth.Contract` and the generated type (`ERC20` in this case) overlapping. There are two reasons for this.

- Instances of a class do not have the constructor as a member - the constructor is a member of the static Class factory. (See https://blog.logrocket.com/writing-constructor-typescript/ for more information.)
- resultValues in an event object are typed as `{ [string:key]: any }` in web3-v1, which does not contain the properties of generated events. For example:
```typescript
export type Approval = ContractEventLog<{
  owner: string;
  spender: string;
  value: string;
  0: string;
  1: string;
  2: string;
}>;

// The expected shape of this type is something like this:
type ExpectedShape = {
  returnValues: {
    owner: string;
    spender: string;
    value: string;
    0: string;
    1: string;
    2: string;
  }
} 

// This means Typescript will throw the error: `{ [key:string]: any }` does not contain properties `owner`, `spender`, etc...
// This is because the shape given by web3-v1 implements this
type ExpectedShape = {
  returnValues: { [key:string]: any }
} 
// Which to the type system, might as well be this.
type ExpectedShape = {
  returnValues: {}
}
// This also applies for Record<string, any>. We could change web3-v1's resultValues type to `any` or `object`, but that's upstream of this repo.

```

**Proposed Changes**
First, remove the constructor from the interface implemented by class instances, and move it into a separate interface meant for typing the static Class:

```typescript
import { ERC20, ERC20Constructor } from '../typechain';

const erc20Factory = this.web3.eth.Contract as ERC20Constructor
const contract1 = new erc20Factory(erc20Artifact, tokenAddress);

// Or,
const contract2 = new this.web3.eth.Contract(erc20Artifact as AbiItem[], tokenAddress) as ERC20;
```
The factory/constructor interface may come in handy for mocking objects in testing, typing higher order functions, etc.

Second, we want to resolve the type mismatch in event callbacks, specifically in the Once methods - 
For now, we can solve this issue by making the return values optional like this:
```typescript
interface ContractEventLog<T> extends EventLog {
  returnValues: Partial<T>
}
```

The above is a stopgap solution until I can either confirm or be denied from changing web3-v1's types upstream. It's not ideal, as we know for a fact that the event WILL contain the properties, but are forced into making them partial to satisfy web3-v1's narrow types.

A benefit of this PR is that users will be able to use the satisfies keyword going forward.
```typescript
const contract2 = new this.web3.eth.Contract(erc20Artifact as AbiItem[], tokenAddress) satisfies ERC20;
```
This keyword provided no benefit before as casting to `unknown`/`any` destroys the underlying information of the type.

Related PRs/Issues: https://github.com/web3/web3.js/pull/2461 (we may be able to get this type changed again to `any` or `object` type, which would allow us to not have to make returnValues as `Partial`.

Other TODOs:
Bump the version of web3-v1 required for this PR to 1.8?