### PR TITLE
fix(ethers-v6): correctly type event listener

### DIFF
--- a/packages/target-ethers-v6/static/common.ts
+++ b/packages/target-ethers-v6/static/common.ts
@@ -2,6 +2,7 @@ import type {
   FunctionFragment,
   Typed,
   EventFragment,
+  ContractEventPayload,
   ContractTransaction,
   ContractTransactionResponse,
   DeferredTopicFilter,
@@ -35,7 +36,7 @@ export interface TypedLogDescription<TCEvent extends TypedContractEvent> extends
 }
 
 export type TypedListener<TCEvent extends TypedContractEvent> = (
-  ...listenerArg: [...__TypechainAOutputTuple<TCEvent>, TypedEventLog<TCEvent>, ...undefined[]]
+  ...listenerArg: [...__TypechainAOutputTuple<TCEvent>, ContractEventPayload, ...undefined[]]
 ) => void
 
 export type MinEthersFactory<C, ARGS> = {


### PR DESCRIPTION
fixes #867 

Not sure about the broader implications of this, but when i made this change to the generated file it correctly types the last event listener arg so one can do

```
  contract.on(
    contract.filters.Swap,
    async (
      address,
      fundsOwner,
      userSellTokenAmount,
      userBuyTokenAmount,
      event
    ) => {
      console.log(event.log.transactionHash) // this
  })
```

seems to be working fine in my script so far
