### PR TITLE
fix: `import type` now includes the module suffix.

### DIFF
--- a/packages/typechain/src/codegen/createBarrelFiles.ts
+++ b/packages/typechain/src/codegen/createBarrelFiles.ts
@@ -56,7 +56,7 @@ export function createBarrelFiles(
 
         if (typeOnly)
           return [
-            `import type * as ${namespaceIdentifier} from './${p}';`,
+            `import type * as ${namespaceIdentifier} from './${p}/index${moduleSuffix}';`,
             `export type { ${namespaceIdentifier} };`,
           ].join('\n')
 


### PR DESCRIPTION
This is necessary for interpreters like `ts-node` or `tsx` that compile typescript just in time.

If you checkout [this repository in this particular branch](https://github.com/wormhole-foundation/wormhole-circle-integration/tree/test-typechain) and run:

```sh
make dependencies
make build
npx tsc --noEmit --project tsconfig.json
```

You'll get errors for the `import type` directives because they're not pointing at modules nor have the `.js` suffix.
If you build and link the `typechain` package in this branch, and run the `yarn build-types` command the codegen will be correct.