### PR TITLE
Fix for barrel file codegen of type-only files

### DIFF
--- a/.changeset/hungry-noodle-dryer.md
+++ b/.changeset/hungry-noodle-dryer.md
@@ -1,0 +1,5 @@
+---
+'typechain': patch
+---
+
+Fix the import syntax for barrel file imports referring to type-only files. Fixes a problem with ESM compatibility when using the `--node16-modules` flag.

--- a/packages/typechain/src/codegen/createBarrelFiles.ts
+++ b/packages/typechain/src/codegen/createBarrelFiles.ts
@@ -54,16 +54,15 @@ export function createBarrelFiles(
       .map((p) => {
         const namespaceIdentifier = normalizeDirName(p)
 
+        const fromFilePath = moduleSuffix ? `'./${p}/index${moduleSuffix}'` : `'./${p}'`
+
         if (typeOnly)
           return [
-            `import type * as ${namespaceIdentifier} from './${p}';`,
+            `import type * as ${namespaceIdentifier} from ${fromFilePath};`,
             `export type { ${namespaceIdentifier} };`,
           ].join('\n')
 
-        if (moduleSuffix) {
-          return `export * as ${namespaceIdentifier} from './${p}/index${moduleSuffix}';`
-        }
-        return `export * as ${namespaceIdentifier} from './${p}';`
+        return `export * as ${namespaceIdentifier} from ${fromFilePath};`
       })
       .join('\n')
 


### PR DESCRIPTION
Fix the import syntax for barrel file imports referring to type-only files. Fixes a problem with ESM compatibility when using the `--node16-modules` flag.

A follow-up to fix  #848

See related comments [here](https://github.com/dethcrypto/TypeChain/issues/819#issuecomment-2030453512) and [here](https://github.com/dethcrypto/TypeChain/issues/793#issuecomment-2030373004)