### PR TITLE
include artifacts with dollar sign characters

### DIFF
--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -68,7 +68,7 @@ subtask(TASK_TYPECHAIN_GENERATE_TYPES)
     const cwd = config.paths.root
 
     const { glob } = await import('typechain')
-    const allFiles = glob(cwd, [`${config.paths.artifacts}/!(build-info)/**/+([a-zA-Z0-9_]).json`])
+    const allFiles = glob(cwd, [`${config.paths.artifacts}/!(build-info)/**/+([a-zA-Z0-9_$]).json`])
     if (typechainCfg.externalArtifacts) {
       allFiles.push(...glob(cwd, typechainCfg.externalArtifacts, false))
     }


### PR DESCRIPTION
The Hardhat plugin ignores artifacts with the `$` symbol in their names.  This is a valid character.  In particular, this leads to incompatibility with the `hardhat-exposed` plugin.

TypeChain is deprecated but still useful, so I'm opening this PR in case anyone wants to fork and publish.